### PR TITLE
Add --log-format server flag to configure output format

### DIFF
--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -48,9 +48,10 @@ func Execute() {
 }
 
 func init() {
-	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Load configuration from `filename`")
+
+	rootCmd.PersistentFlags().StringP("log-format", "l", "text", "Specify log format to use when logging to stderr [text or json]")
 
 	rootCmd.PersistentFlags().StringP(
 		"cluster-id",
@@ -63,6 +64,7 @@ func init() {
 }
 
 func initConfig() {
+	logrus.SetFormatter(getLogFormatter())
 	if cfgFile == "" {
 		return
 	}
@@ -97,4 +99,16 @@ func getConfig() (config.Config, error) {
 	}
 
 	return config, nil
+}
+
+func getLogFormatter() logrus.Formatter {
+	format, _ := rootCmd.PersistentFlags().GetString("log-format")
+
+	if format == "json" {
+		return &logrus.JSONFormatter{}
+	} else if format != "text" {
+		logrus.Warnf("Unknown log format specified (%s), will use default text formatter instead.", format)
+	}
+
+	return &logrus.TextFormatter{FullTimestamp: true}
 }


### PR DESCRIPTION
These changes allows the logger format to be specified when starting the
server, either to `text` (default) or `json`.

I'm also interested in adding support for the fluentd format, though that would mean adding a 3rd party dependency: https://github.com/joonix/log.

Any thoughts about the changes as is and/or possible new dependency?

Refs https://github.com/heptio/authenticator/issues/52