### PR TITLE
Add support for ARNs with paths.

### DIFF
--- a/pkg/arn/arn.go
+++ b/pkg/arn/arn.go
@@ -36,10 +36,11 @@ func Canonicalize(arn string) (string, error) {
 		case "federated-user":
 			return arn, nil
 		case "assumed-role":
-			if len(parts) < 2 {
+			if len(parts) < 3 {
 				return "", fmt.Errorf("assumed-role arn '%s' does not have a role", arn)
 			}
-			role := parts[1]
+			// IAM ARNs can contain paths, part[0] is resource, parts[len(parts)] is the SessionName.
+			role := strings.Join(parts[1:len(parts)-1], "/")
 			return fmt.Sprintf("arn:%s:iam::%s:role/%s", parsed.Partition, parsed.AccountID, role), nil
 		default:
 			return "", fmt.Errorf("unrecognized resource %s for service sts", parsed.Resource)

--- a/pkg/arn/arn_test.go
+++ b/pkg/arn/arn_test.go
@@ -16,6 +16,7 @@ var arnTests = []struct {
 	{"arn:aws:sts::123456789012:assumed-role/Admin/Session", "arn:aws:iam::123456789012:role/Admin", nil},
 	{"arn:aws:sts::123456789012:federated-user/Bob", "arn:aws:sts::123456789012:federated-user/Bob", nil},
 	{"arn:aws:iam::123456789012:root", "arn:aws:iam::123456789012:root", nil},
+	{"arn:aws:sts::123456789012:assumed-role/Org/Team/Admin/Session", "arn:aws:iam::123456789012:role/Org/Team/Admin", nil},
 }
 
 func TestUserARN(t *testing.T) {


### PR DESCRIPTION
IAM ARNs can have paths (ex.
arn:aws:iam::123456789012:assumed-role/org/team/rolename/session).  When
normalizing the assumed role the output only contained the first part of
the path after assumed-role.

This should fix #98 .