### PR TITLE
Update documentation for kops download hooks to improve security

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,17 @@ Perform the following steps to setup Authenticator on a Kops cluster:
          Description=Download AWS Authenticator configs from S3
          [Service]
          Type=oneshot
-         ExecStart=/bin/mkdir -p /srv/kubernetes/aws-iam-authenticator
-         ExecStart=/usr/local/bin/aws s3 cp --recursive s3://KOPS_STATE_STORE/CLUSTER_NAME/addons/authenticator /srv/kubernetes/aws-iam-authenticator/
+         ExecStartPre=/bin/mkdir -p /srv/kubernetes/aws-iam-authenticator
+         ExecStart=/bin/bash -c "/usr/local/bin/aws s3 cp --recursive s3://KOPS_STATE_STORE/CLUSTER_NAME/addons/authenticator /srv/kubernetes/aws-iam-authenticator/ && \
+           /bin/chown 10000 /srv/kubernetes/aws-iam-authenticator/* && \
+           /bin/chmod 600 /srv/kubernetes/aws-iam-authenticator/*.pem"
    ```
-  If using a non-default AMI that does not have the AWS CLI, replace the second ExecStart statement with
+  If using a non-default AMI that does not have the AWS CLI, replace the ExecStart statement with
 
   ```
-  ExecStart=/usr/bin/docker run --net=host --rm -v /srv/kubernetes/aws-iam-authenticator:/srv/kubernetes/aws-iam-authenticator quay.io/coreos/awscli@sha256:7b893bfb22ac582587798b011024f40871cd7424b9026595fd99c2b69492791d aws s3 cp --recursive s3://KOPS_STATE_STORE/CLUSTER_NAME/addons/authenticator /srv/kubernetes/aws-iam-authenticator/
+  ExecStart=/bin/bash -c "/usr/bin/docker run --net=host --rm -v /srv/kubernetes/aws-iam-authenticator:/srv/kubernetes/aws-iam-authenticator quay.io/coreos/awscli@sha256:7b893bfb22ac582587798b011024f40871cd7424b9026595fd99c2b69492791d aws s3 cp --recursive s3://KOPS_STATE_STORE/CLUSTER_NAME/addons/authenticator /srv/kubernetes/aws-iam-authenticator/ && \
+    /bin/chown 10000 /srv/kubernetes/aws-iam-authenticator/* && \
+    /bin/chmod 600 /srv/kubernetes/aws-iam-authenticator/*.pem"
   ```
 3. Apply the changes with `kops update cluster ${CLUSTER_NAME}`.
    If the cluster already exists, roll the cluster with `kops rolling-update cluster ${CLUSTER_NAME}` in order to recreate the master nodes.


### PR DESCRIPTION
The current kops documentation may result in world-readable pem files, which could be viewed as a security risk. Updated the README.md to recommend the following:

- Set file ownership to user `10000` (which should match the user created in Dockerfile)
- Set file permissions of pem files to 'owner read-write' and remove group and other permissions

## Testing
- [x] Created kops cluster with new hooks
- [x] Verified heptio pods started successfully
- [x] Verified ownership and permission of config files
- [x] Authenticated to cluster with IAM credentials and ran various `kubectl` commands