### PR TITLE
Renamed heptio-authenticator-aws -> aws-iam-authenticator

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,8 +2,8 @@
 project_name: authenticator
 
 builds:
-  - binary: heptio-authenticator-aws
-    main: ./cmd/heptio-authenticator-aws/
+  - binary: aws-iam-authenticator
+    main: ./cmd/aws-iam-authenticator/
     goos:
       - darwin
       - linux
@@ -14,33 +14,33 @@ builds:
 
 dockers:
   - image: gcr.io/heptio-images/authenticator
-    binary: heptio-authenticator-aws
+    binary: aws-iam-authenticator
     dockerfile: Dockerfile.scratch
     tag_templates:
      - "{{ .Tag }}-scratch"
      - "{{ .Tag }}"
     latest: false
   - image: gcr.io/heptio-images/authenticator
-    binary: heptio-authenticator-aws
+    binary: aws-iam-authenticator
     dockerfile: Dockerfile.alpine-3.6
     tag_templates:
      - "{{ .Tag }}-alpine-3.6"
     latest: false
   - image: gcr.io/heptio-images/authenticator
-    binary: heptio-authenticator-aws
+    binary: aws-iam-authenticator
     dockerfile: Dockerfile.alpine-3.7
     tag_templates:
      - "{{ .Tag }}-alpine-3.7"
      - "{{ .Tag }}-alpine"
     latest: false
   - image: gcr.io/heptio-images/authenticator
-    binary: heptio-authenticator-aws
+    binary: aws-iam-authenticator
     dockerfile: Dockerfile.debian-jessie
     tag_templates:
      - "{{ .Tag }}-debian-jessie"
     latest: false
   - image: gcr.io/heptio-images/authenticator
-    binary: heptio-authenticator-aws
+    binary: aws-iam-authenticator
     dockerfile: Dockerfile.debian-stretch
     tag_templates:
      - "{{ .Tag }}-debian-stretch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/heptio/authenticator
+go_import_path: github.com/kubernetes-sigs/aws-iam-authenticator
 go:
   - 1.9.x
 

--- a/Dockerfile.alpine-3.6
+++ b/Dockerfile.alpine-3.6
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 FROM alpine:3.6
-RUN adduser -D -u 10000 heptio-authenticator-aws
+RUN adduser -D -u 10000 aws-iam-authenticator
 RUN apk add --update ca-certificates
-COPY heptio-authenticator-aws /
-USER heptio-authenticator-aws
-ENTRYPOINT ["/heptio-authenticator-aws"]
+COPY aws-iam-authenticator /
+USER aws-iam-authenticator
+ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.alpine-3.7
+++ b/Dockerfile.alpine-3.7
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 FROM alpine:3.7
-RUN adduser -D -u 10000 heptio-authenticator-aws
+RUN adduser -D -u 10000 aws-iam-authenticator
 RUN apk add --update ca-certificates
-COPY heptio-authenticator-aws /
-USER heptio-authenticator-aws
-ENTRYPOINT ["/heptio-authenticator-aws"]
+COPY aws-iam-authenticator /
+USER aws-iam-authenticator
+ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.debian-jessie
+++ b/Dockerfile.debian-jessie
@@ -19,10 +19,10 @@ RUN adduser \
     --uid 10000 \
     --disabled-password \
     --disabled-login \
-    heptio-authenticator-aws && \
+    aws-iam-authenticator && \
     apt-get update && \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-COPY heptio-authenticator-aws /
-USER heptio-authenticator-aws
-ENTRYPOINT ["/heptio-authenticator-aws"]
+COPY aws-iam-authenticator /
+USER aws-iam-authenticator
+ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.debian-stretch
+++ b/Dockerfile.debian-stretch
@@ -19,10 +19,10 @@ RUN adduser \
     --uid 10000 \
     --disabled-password \
     --disabled-login \
-    heptio-authenticator-aws && \
+    aws-iam-authenticator && \
     apt-get update && \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-COPY heptio-authenticator-aws /
-USER heptio-authenticator-aws
-ENTRYPOINT ["/heptio-authenticator-aws"]
+COPY aws-iam-authenticator /
+USER aws-iam-authenticator
+ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 FROM alpine:latest
-RUN adduser -D -u 10000 heptio-authenticator-aws
+RUN adduser -D -u 10000 aws-iam-authenticator
 RUN apk add --update ca-certificates
 
 FROM scratch
 COPY --from=0 /etc/passwd /etc/passwd
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY heptio-authenticator-aws /
-USER heptio-authenticator-aws
-ENTRYPOINT ["/heptio-authenticator-aws"]
+COPY aws-iam-authenticator /
+USER aws-iam-authenticator
+ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: build
 
-GITHUB_REPO ?= github.com/heptio/authenticator
+GITHUB_REPO ?= github.com/kubernetes-sigs/aws-iam-authenticator
 GORELEASER := $(shell command -v goreleaser 2> /dev/null)
 
 .PHONY: build test format

--- a/cmd/aws-iam-authenticator/init.go
+++ b/cmd/aws-iam-authenticator/init.go
@@ -36,7 +36,7 @@ var initCmd = &cobra.Command{
 		}
 
 		localCfg := cfg
-		localCfg.GenerateKubeconfigPath = "heptio-authenticator-aws.kubeconfig"
+		localCfg.GenerateKubeconfigPath = "aws-iam-authenticator.kubeconfig"
 		localCfg.StateDir = "./"
 
 		err = localCfg.GenerateFiles()
@@ -48,7 +48,7 @@ var initCmd = &cobra.Command{
 		logrus.Infof("copy %s to %s on kubernetes master node(s)", localCfg.CertPath(), cfg.CertPath())
 		logrus.Infof("copy %s to %s on kubernetes master node(s)", localCfg.KeyPath(), cfg.KeyPath())
 		logrus.Infof("copy %s to %s on kubernetes master node(s)", localCfg.GenerateKubeconfigPath, cfg.GenerateKubeconfigPath)
-		logrus.Infof("configure your apiserver with `--authentication-token-webhook-config-file=%s` to enable authentication with heptio-authenticator-aws", cfg.GenerateKubeconfigPath)
+		logrus.Infof("configure your apiserver with `--authentication-token-webhook-config-file=%s` to enable authentication with aws-iam-authenticator", cfg.GenerateKubeconfigPath)
 	},
 }
 

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/heptio/authenticator/pkg/config"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -31,7 +31,7 @@ import (
 var cfgFile string
 
 var rootCmd = &cobra.Command{
-	Use:   "heptio-authenticator-aws",
+	Use:   "aws-iam-authenticator",
 	Short: "A tool to authenticate to Kubernetes using AWS IAM credentials",
 }
 
@@ -56,7 +56,7 @@ func init() {
 		"cluster-id",
 		"i",
 		"",
-		"Specify the cluster `ID`, a unique-per-cluster identifier for your heptio-authenticator-aws installation.",
+		"Specify the cluster `ID`, a unique-per-cluster identifier for your aws-iam-authenticator installation.",
 	)
 	viper.BindPFlag("clusterID", rootCmd.PersistentFlags().Lookup("cluster-id"))
 	viper.BindEnv("clusterID", "KUBERNETES_AWS_AUTHENTICATOR_CLUSTER_ID")

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"github.com/heptio/authenticator/pkg/server"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/server"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -47,7 +47,7 @@ func init() {
 	viper.SetDefault("server.port", DefaultPort)
 
 	serverCmd.Flags().String("generate-kubeconfig",
-		"/etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml",
+		"/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml",
 		"Output `path` where a generated webhook kubeconfig (for `--authentication-token-webhook-config-file`) will be stored (should be a hostPath mount).")
 	viper.BindPFlag("server.generateKubeconfig", serverCmd.Flags().Lookup("generate-kubeconfig"))
 
@@ -57,7 +57,7 @@ func init() {
 	viper.BindPFlag("server.kubeconfigPregenerated", serverCmd.Flags().Lookup("kubeconfig-pregenerated"))
 
 	serverCmd.Flags().String("state-dir",
-		"/var/heptio-authenticator-aws",
+		"/var/aws-iam-authenticator",
 		"State `directory` for generated certificate and private key (should be a hostPath mount).")
 	viper.BindPFlag("server.stateDir", serverCmd.Flags().Lookup("state-dir"))
 

--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/heptio/authenticator/pkg/token"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/aws-iam-authenticator/verify.go
+++ b/cmd/aws-iam-authenticator/verify.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/heptio/authenticator/pkg/token"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/example.yaml
+++ b/example.yaml
@@ -23,9 +23,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: kube-system
-  name: heptio-authenticator-aws
+  name: aws-iam-authenticator
   labels:
-    k8s-app: heptio-authenticator-aws
+    k8s-app: aws-iam-authenticator
 data:
   config.yaml: |
     # a unique-per-cluster identifier to prevent replay attacks
@@ -77,9 +77,9 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   namespace: kube-system
-  name: heptio-authenticator-aws
+  name: aws-iam-authenticator
   labels:
-    k8s-app: heptio-authenticator-aws
+    k8s-app: aws-iam-authenticator
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -88,7 +88,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        k8s-app: heptio-authenticator-aws
+        k8s-app: aws-iam-authenticator
     spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
@@ -102,18 +102,18 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
 
-      # run `heptio-authenticator-aws server` with three volumes
-      # - config (mounted from the ConfigMap at /etc/heptio-authenticator-aws/config.yaml)
+      # run `aws-iam-authenticator server` with three volumes
+      # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
       # - state (persisted TLS certificate and keys, mounted from the host)
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
-      - name: heptio-authenticator-aws
+      - name: aws-iam-authenticator
         image: gcr.io/heptio-images/authenticator:v0.1.0
         args:
         - server
-        - --config=/etc/heptio-authenticator-aws/config.yaml
-        - --state-dir=/var/heptio-authenticator-aws
-        - --generate-kubeconfig=/etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator
+        - --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
 
         resources:
           requests:
@@ -125,20 +125,20 @@ spec:
 
         volumeMounts:
         - name: config
-          mountPath: /etc/heptio-authenticator-aws/
+          mountPath: /etc/aws-iam-authenticator/
         - name: state
-          mountPath: /var/heptio-authenticator-aws/
+          mountPath: /var/aws-iam-authenticator/
         - name: output
-          mountPath: /etc/kubernetes/heptio-authenticator-aws/
+          mountPath: /etc/kubernetes/aws-iam-authenticator/
 
       volumes:
       - name: config
         configMap:
-          name: heptio-authenticator-aws
+          name: aws-iam-authenticator
       - name: output
         hostPath:
-          path: /etc/kubernetes/heptio-authenticator-aws/
+          path: /etc/kubernetes/aws-iam-authenticator/
       - name: state
         hostPath:
-          path: /var/heptio-authenticator-aws/
+          path: /var/aws-iam-authenticator/
 

--- a/pkg/config/certs.go
+++ b/pkg/config/certs.go
@@ -129,7 +129,7 @@ func selfSignCertificate() ([]byte, []byte, error) {
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName: "heptio-authenticator-aws",
+			CommonName: "aws-iam-authenticator",
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,

--- a/pkg/config/kubeconfig.go
+++ b/pkg/config/kubeconfig.go
@@ -25,7 +25,7 @@ var webhookKubeconfigTemplate = template.Must(
 	template.New("kubeconfig").Option("missingkey=error").Parse(`
 # clusters refers to the remote service.
 clusters:
-  - name: heptio-authenticator-aws
+  - name: aws-iam-authenticator
     cluster:
       certificate-authority-data: {{.CertificateAuthorityBase64}}
       server: {{.ServerURL}}
@@ -38,7 +38,7 @@ current-context: webhook
 contexts:
 - name: webhook
   context:
-    cluster: heptio-authenticator-aws
+    cluster: aws-iam-authenticator
     user: apiserver
 `))
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -56,10 +56,10 @@ type UserMapping struct {
 	Groups []string
 }
 
-// Config specifies the configuration for a heptio-authenticator-aws server
+// Config specifies the configuration for a aws-iam-authenticator server
 type Config struct {
 	// ClusterID is a unique-per-cluster identifier for your
-	// heptio-authenticator-aws installation.
+	// aws-iam-authenticator installation.
 	ClusterID string
 
 	// KubeconfigPregenerated is set to `true` when a webhook kubeconfig is
@@ -95,7 +95,7 @@ type Config struct {
 
 	// ServerEC2DescribeInstancesRoleARN is an optional AWS Resource Name for an IAM Role to be assumed
 	// before calling ec2:DescribeInstances to determine the private DNS of the calling kubelet (EC2 Instance).
-	// If nil, defaults to using the IAM Role attached to the instance where heptio-authenticator-aws is
+	// If nil, defaults to using the IAM Role attached to the instance where aws-iam-authenticator is
 	// running.
 	ServerEC2DescribeInstancesRoleARN string
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,9 +28,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/heptio/authenticator/pkg/arn"
-	"github.com/heptio/authenticator/pkg/config"
-	"github.com/heptio/authenticator/pkg/token"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/arn"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -268,7 +268,7 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 	}
 
 	// use a prefixed UID that includes the AWS account ID and AWS user ID ("AROAAAAAAAAAAAAAAAAAA")
-	uid := fmt.Sprintf("heptio-authenticator-aws:%s:%s", identity.AccountID, identity.UserID)
+	uid := fmt.Sprintf("aws-iam-authenticator:%s:%s", identity.AccountID, identity.UserID)
 
 	// the token is valid and the role is mapped, return success!
 	log.WithFields(logrus.Fields{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,8 +13,8 @@ import (
 
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 
-	"github.com/heptio/authenticator/pkg/config"
-	"github.com/heptio/authenticator/pkg/token"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -289,7 +289,7 @@ func TestAuthenticateVerifierRoleMapping(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, was %d", http.StatusOK, resp.Code)
 	}
-	verifyAuthResult(t, resp, tokenReview("TestUser", "heptio-authenticator-aws:0123456789012:Test", []string{"sys:admin", "listers"}))
+	verifyAuthResult(t, resp, tokenReview("TestUser", "aws-iam-authenticator:0123456789012:Test", []string{"sys:admin", "listers"}))
 	validateMetrics(t, validateOpts{success: 1})
 }
 
@@ -323,7 +323,7 @@ func TestAuthenticateVerifierUserMapping(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, was %d", http.StatusOK, resp.Code)
 	}
-	verifyAuthResult(t, resp, tokenReview("TestUser", "heptio-authenticator-aws:0123456789012:Test", []string{"sys:admin", "listers"}))
+	verifyAuthResult(t, resp, tokenReview("TestUser", "aws-iam-authenticator:0123456789012:Test", []string{"sys:admin", "listers"}))
 	validateMetrics(t, validateOpts{success: 1})
 }
 
@@ -353,7 +353,7 @@ func TestAuthenticateVerifierAccountMappingForUser(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, was %d", http.StatusOK, resp.Code)
 	}
-	verifyAuthResult(t, resp, tokenReview("arn:aws:iam::0123456789012:user/Test", "heptio-authenticator-aws:0123456789012:Test", nil))
+	verifyAuthResult(t, resp, tokenReview("arn:aws:iam::0123456789012:user/Test", "aws-iam-authenticator:0123456789012:Test", nil))
 	validateMetrics(t, validateOpts{success: 1})
 }
 
@@ -383,7 +383,7 @@ func TestAuthenticateVerifierAccountMappingForRole(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, was %d", http.StatusOK, resp.Code)
 	}
-	verifyAuthResult(t, resp, tokenReview("arn:aws:iam::0123456789012:role/Test", "heptio-authenticator-aws:0123456789012:Test", nil))
+	verifyAuthResult(t, resp, tokenReview("arn:aws:iam::0123456789012:role/Test", "aws-iam-authenticator:0123456789012:Test", nil))
 	validateMetrics(t, validateOpts{success: 1})
 }
 
@@ -418,7 +418,7 @@ func TestAuthenticateVerifierNodeMapping(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, was %d", http.StatusOK, resp.Code)
 	}
-	verifyAuthResult(t, resp, tokenReview("system:node:ip-172-31-27-14", "heptio-authenticator-aws:0123456789012:TestNodeRole", []string{"system:nodes", "system:bootstrappers"}))
+	verifyAuthResult(t, resp, tokenReview("system:node:ip-172-31-27-14", "aws-iam-authenticator:0123456789012:TestNodeRole", []string{"system:nodes", "system:bootstrappers"}))
 	validateMetrics(t, validateOpts{success: 1})
 
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package server
 
 import (
-	"github.com/heptio/authenticator/pkg/config"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
 )
 
 // Server for the authentication webhook.
 type Server struct {
-	// Config is the whole configuration of heptio-authenticator-aws used for valid keys and certs, kubeconfig, and so on
+	// Config is the whole configuration of aws-iam-authenticator used for valid keys and certs, kubeconfig, and so on
 	config.Config
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -32,7 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/heptio/authenticator/pkg/arn"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/arn"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientauthv1alpha1 "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
 )


### PR DESCRIPTION
Now that the repository has moved, we can rename to aws-iam-authenticator.

Signed-off-by: Nick Turner <nic@amazon.com>