### PR TITLE
Adding a flag to only output the token

### DIFF
--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -33,6 +33,7 @@ var tokenCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		roleARN := viper.GetString("role")
 		clusterID := viper.GetString("clusterID")
+		tokenOnly := viper.GetBool("tokenOnly")
 
 		if clusterID == "" {
 			fmt.Fprintf(os.Stderr, "Error: cluster ID not specified\n")
@@ -58,13 +59,18 @@ var tokenCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "could not get token: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(gen.FormatJSON(tok))
+		if !tokenOnly {
+			tok = gen.FormatJSON(tok)
+		}
+		fmt.Println(tok)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(tokenCmd)
 	tokenCmd.Flags().StringP("role", "r", "", "Assume an IAM Role ARN before signing this token")
+	tokenCmd.Flags().Bool("token-only", false, "Return only the token for use with Bearer token based tools")
 	viper.BindPFlag("role", tokenCmd.Flags().Lookup("role"))
+	viper.BindPFlag("tokenOnly", tokenCmd.Flags().Lookup("token-only"))
 	viper.BindEnv("role", "DEFAULT_ROLE")
 }


### PR DESCRIPTION
**Why:**

* This enables you to use the authenticator binary to generate
  short-lived access to tools like the Kubernetes Dashboard using the
  token field

**This change addresses the need by:**

* closes #85

**Usecase:**

```sh
aws-iam-authenticator -i <cluster-name> --only-token 
```

Signed-off-by: Christopher Hein <me@christopherhein.com>