### PR TITLE
Adding configs to allow you to run from local

### DIFF
--- a/cmd/aws-iam-authenticator/init.go
+++ b/cmd/aws-iam-authenticator/init.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var initCmd = &cobra.Command{
@@ -53,5 +54,17 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.Flags().String(
+		"hostname",
+		"localhost",
+		"Hostname that should be used for writing into the selfsigned certificates")
+	viper.BindPFlag("server.hostname", initCmd.Flags().Lookup("hostname"))
+
+	initCmd.Flags().String(
+		"address",
+		"127.0.0.1",
+		"IP Address to bind the server to listen to. (should be a 127.0.0.1 or 0.0.0.0)")
+	viper.BindPFlag("server.address", initCmd.Flags().Lookup("address"))
+
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -79,10 +79,12 @@ func getConfig() (config.Config, error) {
 	config := config.Config{
 		ClusterID:                         viper.GetString("clusterID"),
 		ServerEC2DescribeInstancesRoleARN: viper.GetString("server.ec2DescribeInstancesRoleARN"),
-		LocalhostPort:                     viper.GetInt("server.port"),
-		GenerateKubeconfigPath:            viper.GetString("server.generateKubeconfig"),
-		KubeconfigPregenerated:            viper.GetBool("server.kubeconfigPregenerated"),
-		StateDir:                          viper.GetString("server.stateDir"),
+		HostPort:               viper.GetInt("server.port"),
+		Hostname:               viper.GetString("server.hostname"),
+		GenerateKubeconfigPath: viper.GetString("server.generateKubeconfig"),
+		KubeconfigPregenerated: viper.GetBool("server.kubeconfigPregenerated"),
+		StateDir:               viper.GetString("server.stateDir"),
+		Address:                viper.GetString("server.address"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &config.RoleMappings); err != nil {
 		return config, fmt.Errorf("invalid server role mappings: %v", err)

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -61,5 +61,12 @@ func init() {
 		"State `directory` for generated certificate and private key (should be a hostPath mount).")
 	viper.BindPFlag("server.stateDir", serverCmd.Flags().Lookup("state-dir"))
 
+	serverCmd.Flags().StringP(
+		"bind",
+		"b",
+		"127.0.0.1",
+		"IP Address to bind the server to listen to. (should be a 127.0.0.1 or 0.0.0.0)")
+	viper.BindPFlag("server.bind", serverCmd.Flags().Lookup("bind"))
+
 	rootCmd.AddCommand(serverCmd)
 }

--- a/pkg/config/certs.go
+++ b/pkg/config/certs.go
@@ -41,6 +41,7 @@ func (c *Config) keyPath() string {
 	return filepath.Join(c.StateDir, keyFilename)
 }
 
+// GetOrCreateCertificate will create a certificate if it cannot find one based on the config
 func (c *Config) GetOrCreateCertificate() (*tls.Certificate, error) {
 	// first try to load the existing keypair
 	cert, err := c.LoadExistingCertificate()
@@ -53,7 +54,7 @@ func (c *Config) GetOrCreateCertificate() (*tls.Certificate, error) {
 	}
 
 	// generate a self-signed certificate and write out the certificate and private key
-	certBytes, keyBytes, err := selfSignCertificate()
+	certBytes, keyBytes, err := c.selfSignCertificate()
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +77,7 @@ func (c *Config) GetOrCreateCertificate() (*tls.Certificate, error) {
 	return &newCert, err
 }
 
+// LoadExistingCertificate will load certificates from a local path
 func (c *Config) LoadExistingCertificate() (*tls.Certificate, error) {
 
 	// if either file does not exist, we'll consider that not an error but
@@ -107,7 +109,7 @@ func dumpPEM(filename string, mode os.FileMode, blockType string, bytes []byte) 
 	return pem.Encode(f, &pem.Block{Type: blockType, Bytes: bytes})
 }
 
-func selfSignCertificate() ([]byte, []byte, error) {
+func (c *Config) selfSignCertificate() ([]byte, []byte, error) {
 
 	// generate a new RSA-2048 keypair
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -137,8 +139,8 @@ func selfSignCertificate() ([]byte, []byte, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:        true,
-		DNSNames:    []string{"localhost"},
-		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:    []string{c.Hostname},
+		IPAddresses: []net.IP{net.ParseIP(c.Address)},
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,8 +28,7 @@ func (c *Config) ListenURL() string {
 }
 
 func (c *Config) ListenAddr() string {
-	// we always listen on localhost (and run with host networking)
-	return fmt.Sprintf("127.0.0.1:%d", c.LocalhostPort)
+	return fmt.Sprintf("%d:%d", c.Hostname, c.HostPort)
 }
 
 func (c *Config) GenerateFiles() error {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -67,9 +67,11 @@ type Config struct {
 	// `server` shouldn't unnecessarily re-generate a new one.
 	KubeconfigPregenerated bool
 
-	// LocalhostPort is the TCP on which to listen for authentication checks
-	// (on localhost).
-	LocalhostPort int
+	// HostPort is the TCP Port on which to listen for authentication checks.
+	HostPort int
+
+	// Hostname is the hostname that the server bind to.
+	Hostname string
 
 	// GenerateKubeconfigPath is the output path where a generated webhook
 	// kubeconfig (for `--authentication-token-webhook-config-file`) will be
@@ -98,4 +100,8 @@ type Config struct {
 	// If nil, defaults to using the IAM Role attached to the instance where aws-iam-authenticator is
 	// running.
 	ServerEC2DescribeInstancesRoleARN string
+
+	// Address defines the hostname or IP Address to bind the HTTPS server to listen to. This is useful when creating
+	// a local server to handle the authentication request for development.
+	Address string
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -117,8 +117,7 @@ func (c *Server) Run() {
 		logrus.WithField("accountID", account).Infof("mapping IAM Account")
 	}
 
-	// we always listen on localhost (and run with host networking)
-	listenAddr := fmt.Sprintf("127.0.0.1:%d", c.LocalhostPort)
+	listenAddr := fmt.Sprintf("%s:%d", c.Address, c.HostPort)
 	listenURL := fmt.Sprintf("https://%s/authenticate", listenAddr)
 
 	cert, err := c.GetOrCreateCertificate()
@@ -342,6 +341,7 @@ func (h *handler) renderTemplate(template string, identity *token.Identity) (str
 	return template, nil
 }
 
+// EC2Provider configures a DNS resolving function for nodes
 type EC2Provider interface {
 	// Get a node name from instance ID
 	getPrivateDNSName(string) (string, error)


### PR DESCRIPTION
**Why:**

* This makes development much easier allowing you to pass `--kubeconfig`
  to a local directory and have it listen to the remote apiserver
* Caveat! This needs to also be configured with the auth webhook so
  development requires an addressable server

**Issue:** closes #123 