### PR TITLE
feat(verify): creating output format option for verify command

### DIFF
--- a/cmd/aws-iam-authenticator/verify.go
+++ b/cmd/aws-iam-authenticator/verify.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -32,6 +33,7 @@ var verifyCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		tok := viper.GetString("token")
+		output := viper.GetString("output")
 		clusterID := viper.GetString("clusterID")
 
 		if tok == "" {
@@ -52,12 +54,22 @@ var verifyCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("%+v\n", id)
+		if output == "json" {
+			value, err := json.MarshalIndent(id, "", "    ")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "could not unmarshal token: %v\n", err)
+			}
+			fmt.Printf("%s\n", value)
+		} else {
+			fmt.Printf("%+v\n", id)
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(verifyCmd)
 	verifyCmd.Flags().StringP("token", "t", "", "Verify this token")
+	verifyCmd.Flags().StringP("output", "o", "", "Output format. Only `json` is supported currenty.")
 	viper.BindPFlag("token", verifyCmd.Flags().Lookup("token"))
+	viper.BindPFlag("output", verifyCmd.Flags().Lookup("output"))
 }


### PR DESCRIPTION
Wanted to be able to use the verify command and not have to parse out data from it in an unusual way.

Not sure if this is needed or not. I know this command is listed as, "Verify a token for debugging purpose" but it's actually pretty useful for determining who a token belongs too.