### PR TITLE
#125 Adding `version` subcommand

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,9 @@
 # Configuration for https://goreleaser.com/
 project_name: authenticator
 
+git:
+  short_hash: true
+
 builds:
   - binary: aws-iam-authenticator
     main: ./cmd/aws-iam-authenticator/
@@ -12,6 +15,8 @@ builds:
       - amd64
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
 
 dockers:
   - image: gcr.io/heptio-images/authenticator

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 install:
-  - curl -s -L --retry 8 -o /tmp/goreleaser.tgz https://github.com/goreleaser/goreleaser/releases/download/v0.45.1/goreleaser_Linux_x86_64.tar.gz
+  - curl -s -L --retry 8 -o /tmp/goreleaser.tgz https://github.com/goreleaser/goreleaser/releases/download/v0.82.2/goreleaser_Linux_x86_64.tar.gz
   - tar -xzvf /tmp/goreleaser.tgz -C /tmp/
   - sudo mv /tmp/goreleaser /usr/local/bin
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,6 +53,12 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/christopherhein/go-version"
+  packages = ["."]
+  revision = "fee8dd1f7c24da23508e26347694be0acce5631b"
+
+[[projects]]
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
@@ -376,6 +382,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "10414834174a87ee92d8503de766220911531a7c1e7d3c251889923abe26c80e"
+  inputs-digest = "51715b2ad17974bbee0c156f1813a871098e9faec6a68074caabde91a4f6fe91"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/aws-iam-authenticator/version.go
+++ b/cmd/aws-iam-authenticator/version.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	goVersion "github.com/christopherhein/go-version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	shortened  = false
+	version    = ""
+	commit     = ""
+	date       = ""
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Version will output the current build information",
+		Long:  ``,
+		Run: func(_ *cobra.Command, _ []string) {
+			var response string
+			versionOutput := goVersion.New(version, commit, date)
+
+			if shortened {
+				response = versionOutput.ToShortened()
+			} else {
+				response = versionOutput.ToJSON()
+			}
+			fmt.Printf("%+v", response)
+			return
+		},
+	}
+)
+
+func init() {
+	versionCmd.Flags().BoolVarP(&shortened, "short", "s", false, "Use shortened output for version information.")
+	rootCmd.AddCommand(versionCmd)
+}

--- a/vendor/github.com/christopherhein/go-version/CONTRIBUTING.adoc
+++ b/vendor/github.com/christopherhein/go-version/CONTRIBUTING.adoc
@@ -1,0 +1,31 @@
+= Contributing
+
+⭐️⭐️⭐️⭐️⭐️ First off thanks for taking the time to contribute ⭐️⭐️⭐️⭐️⭐️
+
+This project is extremely simple and gives a generic way to get a version out of
+your `goreleaser` and `cobra` projects. All the code is contained in a single
+package `version.go`.
+
+== Roadmap
+
+If you are interested in contributing to this project here are a couple things
+that I would like to add.
+
+1. **Issue: link:https://github.com/christopherhein/go-version/issues/1[#1]**
+   Support for custom attributes `-X main.foobar=<blah>` and updating
+   `goVersion.New()` to take a splat or map of addition params.
+2. **Issue: https://github.com/christopherhein/go-version/issues/2[#2]**
+   Ability to Output to `yaml`
+3. **Issue: https://github.com/christopherhein/go-version/issues/3[#3]**
+   Func for taking in a type string and outputting the right response
++
+**Example:**
++
+[source,go]
+----
+info := goVersion.New(...)
+info.Output('json')
+----
+4. **Issue: https://github.com/christopherhein/go-version/issues/4[#4]**
+   Tests 😳
+

--- a/vendor/github.com/christopherhein/go-version/LICENSE.txt
+++ b/vendor/github.com/christopherhein/go-version/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/christopherhein/go-version/readme.adoc
+++ b/vendor/github.com/christopherhein/go-version/readme.adoc
@@ -1,0 +1,81 @@
+= Go Version
+
+This package gives allows you to use https://github.com/spf13/cobra and
+https://github.com/goreleaser/goreleaser together to output your version in a
+simple way. Supporting multiple flags for mutating the output.
+
+== Usage
+
+To use this package you will need to create `cobra` command for version such as
+this:
+
+[source,go]
+----
+package main
+
+import (
+	"fmt"
+	goVersion "github.com/christopherhein/go-version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	shortened  = false
+	version    = "dev"
+	commit     = "none"
+	date       = "unknown"
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Version will output the current build information",
+		Long:  ``,
+		Run: func(_ *cobra.Command, _ []string) {
+			var response string
+			versionOutput := goVersion.New(version, commit, date)
+
+			if shortened {
+				response = versionOutput.ToShortened()
+			} else {
+				response = versionOutput.ToJSON()
+			}
+			fmt.Printf("%+v", response)
+			return
+		},
+	}
+)
+
+func init() {
+	versionCmd.Flags().BoolVarP(&shortened, "short", "s", false, "Use shortened output for version information.")
+	rootCmd.AddCommand(versionCmd)
+}
+----
+
+When you do this then you can pass in these flags at build time.
+
+[source,shell]
+----
+go build -ldflags "-X main.commit=<SOMEHASH> -X main.date=<SOMEDATE>"
+----
+
+This then gives your CLI thw ability to use this for the JSON output:
+
+[source,shell]
+----
+$ ./my-cli version
+{"Version":"dev","Commit":"<SOMEHASH>","Date":"<SOMEDATE>"}
+----
+
+Or to make this human readible you could use:
+
+[source,shell]
+----
+$ ./my-cli -s
+
+Version: dev
+Commit: <SOMEHASH>
+Date: <SOMEDATE>
+----
+
+== Contributing
+
+If you want to contribute check out
+https://github.com/christopherhein/go-version/blob/master/CONTRIBUTING.adoc

--- a/vendor/github.com/christopherhein/go-version/version.go
+++ b/vendor/github.com/christopherhein/go-version/version.go
@@ -1,0 +1,56 @@
+package version
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Info creates a formattable struct for output
+type Info struct {
+	Version string `json:"Version,omitempty"`
+	Commit  string `json:"Commit,omitempty"`
+	Date    string `json:"Date,omitempty"`
+}
+
+// New will create a pointer to a new version object
+func New(version string, commit string, date string) *Info {
+	return &Info{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	}
+}
+
+// ToJSON converts the Info into a JSON String
+func (v *Info) ToJSON() string {
+	bytes, _ := json.Marshal(v)
+	return string(bytes) + "\n"
+}
+
+// ToShortened converts the Info into a JSON String
+func (v *Info) ToShortened() (str string) {
+	var version, commit, date string
+	if v.Version != "" {
+		version = "Version: " + v.Version
+	}
+	if v.Commit != "" {
+		commit = "Commit: " + v.Commit
+	}
+	if v.Date != "" {
+		date = "Date: " + v.Date
+	}
+	values := []string{version, commit, date}
+	values = deleteEmpty(values)
+	str = strings.Join(values, "\n")
+	return str + "\n"
+}
+
+func deleteEmpty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}


### PR DESCRIPTION
**Why:**

* allows you to echo the version of the build, uses built in `goreleaser` `ldflags` to get the latest release information
    
**This change addresses the need by:**
    
* closes #125
    
Signed-off-by: Christopher Hein <me@christopherhein.com>

```bash
→ ./dist/darwin_amd64/aws-iam-authenticator version -s
Version: v0.3.0
Commit: 01dd27d
→ 
→ ./dist/darwin_amd64/aws-iam-authenticator version
{"Version":"v0.3.0","Commit":"01dd27d"}

```

We can customize what params are enabled by using the `build` section in the `.goreleaser.yaml` file like so:

```yaml
  build:
    # ....
    ldflags:
    - "-s -w -X main.version={{.Tag}} -X main.commit={{.Commit}}"
```