### PR TITLE
Role assumption names

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ users:
 This method allows the appropriate profile to be used implicitly. Note that any environment variables set as part of the `exec` flow will
 take precedence over what's already set in your environment.
 
+#### Note for federated users:
+Federated AWS users often will have a "meaningful" attribute mapped onto their assumed role, such as an email address, through the account's AWS configuration.
+These assumed sessions have [a few parts](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable), the `role id`
+and `caller-specified-role-name`. By default, when a federated user uses the `--role` option of `aws-iam-authenticator` to assume a new role the
+`caller-specified-role-name` will be converted to a random token and the `role id` carries through to the newly assumed role.
+
+Using `aws-iam-authenticator token ... --forward-session-name` will map the original `caller-specified-role-name` attribute onto the new STS assumed session.
+This can be helpful for quickly attempting to associate "who performed action X on the K8 cluster".
+
+Please note, **this should not be considered definitive** and needs to be cross referenced via the `role id` (which remains consistent) with CloudTrail logs
+as a user could potentially change this on the client side.
+
 ## Troubleshooting
 
 If your client fails with an error like `could not get token: AccessDenied [...]`, you can try assuming the role with the AWS CLI directly:

--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -34,6 +34,7 @@ var tokenCmd = &cobra.Command{
 		roleARN := viper.GetString("role")
 		clusterID := viper.GetString("clusterID")
 		tokenOnly := viper.GetBool("tokenOnly")
+		forwardSessionName := viper.GetBool("forwardSessionName")
 
 		if clusterID == "" {
 			fmt.Fprintf(os.Stderr, "Error: cluster ID not specified\n")
@@ -43,7 +44,7 @@ var tokenCmd = &cobra.Command{
 
 		var tok string
 		var err error
-		gen, err := token.NewGenerator()
+		gen, err := token.NewGenerator(forwardSessionName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not get token: %v\n", err)
 			os.Exit(1)
@@ -70,7 +71,12 @@ func init() {
 	rootCmd.AddCommand(tokenCmd)
 	tokenCmd.Flags().StringP("role", "r", "", "Assume an IAM Role ARN before signing this token")
 	tokenCmd.Flags().Bool("token-only", false, "Return only the token for use with Bearer token based tools")
+	tokenCmd.Flags().Bool("forward-session-name",
+		false,
+		"Enable mapping a federated sessions caller-specified-role-name attribute onto newly assumed sessions. NOTE: Only applicable when a new role is requested via --role")
 	viper.BindPFlag("role", tokenCmd.Flags().Lookup("role"))
 	viper.BindPFlag("tokenOnly", tokenCmd.Flags().Lookup("token-only"))
+	viper.BindPFlag("forwardSessionName", tokenCmd.Flags().Lookup("forward-session-name"))
 	viper.BindEnv("role", "DEFAULT_ROLE")
+
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ func (c *Config) ListenURL() string {
 }
 
 func (c *Config) ListenAddr() string {
-	return fmt.Sprintf("%d:%d", c.Hostname, c.HostPort)
+	return fmt.Sprintf("%s:%d", c.Hostname, c.HostPort)
 }
 
 func (c *Config) GenerateFiles() error {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -184,24 +184,27 @@ func (g generator) GetWithRoleForSession(clusterID string, roleARN string, sess 
 
 	// if a roleARN was specified, replace the STS client with one that uses
 	// temporary credentials from that role.
-	if roleARN != "" && g.forwardSessionName {
-		// Determine if the current session is already a federated identity.  If so,
-		// we carry through this session name onto the new session to provide better
-		// aduiting capabilities
-		//
-		// NOTE: I couldn't figure out a more `direct` way of indicating if the
-		// current Caller Identity's PrincipalType is `Federated`
-		// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)
-		// If there is a more direct approach I would be interested in understanding
-		resp, err := stsAPI.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-		if err != nil {
-			return "", err
-		}
+	if roleARN != "" {
+		sessionSetter := func(provider *stscreds.AssumeRoleProvider) {}
+		if g.forwardSessionName {
+			// Determine if the current session is already a federated identity.  If so,
+			// we carry through this session name onto the new session to provide better
+			// aduiting capabilities
+			//
+			// NOTE: I couldn't figure out a more `direct` way of indicating if the
+			// current Caller Identity's PrincipalType is `Federated`
+			// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)
+			// If there is a more direct approach I would be interested in understanding
+			resp, err := stsAPI.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+			if err != nil {
+				return "", err
+			}
 
-		userIDParts := strings.Split(*resp.UserId, ":")
-		sessionSetter := func(provider *stscreds.AssumeRoleProvider) {
-			if len(userIDParts) == 2 {
-				provider.RoleSessionName = userIDParts[1]
+			userIDParts := strings.Split(*resp.UserId, ":")
+			sessionSetter = func(provider *stscreds.AssumeRoleProvider) {
+				if len(userIDParts) == 2 {
+					provider.RoleSessionName = userIDParts[1]
+				}
 			}
 		}
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -187,14 +187,9 @@ func (g generator) GetWithRoleForSession(clusterID string, roleARN string, sess 
 	if roleARN != "" {
 		sessionSetter := func(provider *stscreds.AssumeRoleProvider) {}
 		if g.forwardSessionName {
-			// Determine if the current session is already a federated identity.  If so,
-			// we carry through this session name onto the new session to provide better
-			// aduiting capabilities
-			//
-			// NOTE: I couldn't figure out a more `direct` way of indicating if the
-			// current Caller Identity's PrincipalType is `Federated`
-			// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)
-			// If there is a more direct approach I would be interested in understanding
+			// If the current session is already a federated identity, carry through 
+			// this session name onto the new session to provide better debugging
+			// capabilities
 			resp, err := stsAPI.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 			if err != nil {
 				return "", err

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -137,11 +137,14 @@ type Generator interface {
 }
 
 type generator struct {
+	forwardSessionName bool
 }
 
 // NewGenerator creates a Generator and returns it.
-func NewGenerator() (Generator, error) {
-	return generator{}, nil
+func NewGenerator(forwardSessionName bool) (Generator, error) {
+	return generator{
+		forwardSessionName: forwardSessionName,
+	}, nil
 }
 
 // Get uses the directly available AWS credentials to return a token valid for
@@ -181,7 +184,7 @@ func (g generator) GetWithRoleForSession(clusterID string, roleARN string, sess 
 
 	// if a roleARN was specified, replace the STS client with one that uses
 	// temporary credentials from that role.
-	if roleARN != "" {
+	if roleARN != "" && g.forwardSessionName {
 		// Determine if the current session is already a federated identity.  If so,
 		// we carry through this session name onto the new session to provide better
 		// aduiting capabilities


### PR DESCRIPTION
Fixes #120
See conversation from #121 for additional context/discussion

When using a federated user session in conjunction with
the -r role assumption option, some of the fidelity of that
initial session is lost (ex: caller-specified-name from
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)

This will conditionally check, if a new role is asked to be assumed,
if there is already an existing role specified and if so, it will
pass it through to the new session to allow for easier auditing
of users as they traverse more complex IAM role delegation structures.

- [ ] Ensure proper fallback for role assumption without session forwarding