### PR TITLE
Fix format string of ListenUrl in config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ func (c *Config) ListenURL() string {
 }
 
 func (c *Config) ListenAddr() string {
-	return fmt.Sprintf("%d:%d", c.Hostname, c.HostPort)
+	return fmt.Sprintf("%s:%d", c.Hostname, c.HostPort)
 }
 
 func (c *Config) GenerateFiles() error {


### PR DESCRIPTION
This currently causes the `init` command to output e.g. `https://%!d(string=localhost):21362/authenticate`.