### PR TITLE
Add cache functionality for tokens

### DIFF
--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -35,6 +35,7 @@ var tokenCmd = &cobra.Command{
 		clusterID := viper.GetString("clusterID")
 		tokenOnly := viper.GetBool("tokenOnly")
 		forwardSessionName := viper.GetBool("forwardSessionName")
+		useCache := viper.GetBool("cache")
 
 		if clusterID == "" {
 			fmt.Fprintf(os.Stderr, "Error: cluster ID not specified\n")
@@ -45,7 +46,7 @@ var tokenCmd = &cobra.Command{
 		var tok token.Token
 		var out string
 		var err error
-		gen, err := token.NewGenerator(forwardSessionName)
+		gen, err := token.NewGenerator(forwardSessionName, useCache)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not get token: %v\n", err)
 			os.Exit(1)
@@ -77,8 +78,10 @@ func init() {
 	tokenCmd.Flags().Bool("forward-session-name",
 		false,
 		"Enable mapping a federated sessions caller-specified-role-name attribute onto newly assumed sessions. NOTE: Only applicable when a new role is requested via --role")
+	tokenCmd.Flags().Bool("cache", false, "Store token in cache")
 	viper.BindPFlag("role", tokenCmd.Flags().Lookup("role"))
 	viper.BindPFlag("tokenOnly", tokenCmd.Flags().Lookup("token-only"))
 	viper.BindPFlag("forwardSessionName", tokenCmd.Flags().Lookup("forward-session-name"))
+	viper.BindPFlag("cache", tokenCmd.Flags().Lookup("cache"))
 	viper.BindEnv("role", "DEFAULT_ROLE")
 }


### PR DESCRIPTION
As we have been running into the same issue as #99 and I hadn't seen any progress on that issue, I took a stab at it myself. This adds optional cache functionality that keeps the token valid for an hour and stores it in the cache directory.

This means we no longer have to provide a new MFA token for every single kubectl invocation.