### PR TITLE
Log the STS response on success

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -253,6 +253,13 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	log.WithFields(logrus.Fields{
+		"arn": identity.ARN,
+		"accountid": identity.AccountID,
+		"userid": identity.UserID,
+		"session": identity.SessionName,
+	}).Info("STS response")
+
 	// look up the ARN in each of our mappings to fill in the username and groups
 	arnLower := strings.ToLower(identity.CanonicalARN)
 	log = log.WithField("arn", identity.CanonicalARN)


### PR DESCRIPTION
Currently, parts of the STS response are logged as the uid after
mapping lookup, but this include the SessionName (previously unincluded)
along with the account ID, identity ARN, and UserId (Principle ID).