### PR TITLE
Add support for multiple regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ server:
   # role to assume before querying EC2 API in order to discover metadata like EC2 private DNS Name
   ec2DescribeInstancesRoleARN: arn:aws:iam::000000000000:role/DescribeInstancesRole
 
+  # list of AWS regions to search for instances when resolving {{EC2PrivateDNSName}}
+  # if none specified it will look only in the region running the authentcator.
+  regions: ["us-west-1", "us-east-1"]
+
   # each mapRoles entry maps an IAM role to a username and set of groups
   # Each username and group can optionally contain template parameters:
   #  1) "{{AccountID}}" is the 12 digit AWS ID.

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -95,6 +95,9 @@ func getConfig() (config.Config, error) {
 		Master:                            viper.GetString("server.master"),
 		FeatureGates:                      featureGates,
 	}
+	if err := viper.UnmarshalKey("server.regions", &cfg.Regions); err != nil {
+		return cfg, fmt.Errorf("invalid server region list: %v", err)
+	}
 	if err := viper.UnmarshalKey("server.mapRoles", &cfg.RoleMappings); err != nil {
 		return cfg, fmt.Errorf("invalid server role mappings: %v", err)
 	}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -105,6 +105,9 @@ type Config struct {
 	// running.
 	ServerEC2DescribeInstancesRoleARN string
 
+	// List of AWS regions to search for instances when resolving {{EC2PrivateDNSName}}
+	Regions []string
+
 	// Address defines the hostname or IP Address to bind the HTTPS server to listen to. This is useful when creating
 	// a local server to handle the authentication request for development.
 	Address string

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -66,7 +66,7 @@ type testEC2Provider struct {
 	name string
 }
 
-func (p *testEC2Provider) getPrivateDNSName(id string) (string, error) {
+func (p *testEC2Provider) getPrivateDNSName(id string, regions []string) (string, error) {
 	return p.name, nil
 }
 


### PR DESCRIPTION
When resolving `{{EC2PrivateDNSName}}`, authenticator looks for instances only in the current region. This PR adds an optional setting allowing to specify other regions to query.

This allows to have single cluster spanning multiple AWS regions that are connected using peered VPC. 