### PR TITLE
Fix UTC time conversion bug.

### DIFF
--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -36,7 +36,7 @@ func assertSTSError(t *testing.T, err error) {
 
 var (
 	now        = time.Now()
-	timeStr    = now.Format("20060102T150405Z")
+	timeStr    = now.UTC().Format("20060102T150405Z")
 	validToken = toToken(validURL)
 	validURL   = fmt.Sprintf("https://sts.amazonaws.com/?action=GetCallerIdentity&x-amz-signedheaders=x-k8s-aws-id&x-amz-expires=60&x-amz-date=%s", timeStr)
 )


### PR DESCRIPTION
Golang has a weird time formatting system.  It does not do time
zone conversion for you.  If you want to output UTC, you must first
convert your time to UTC.  Previously, this test would only work on
a machine that happened to be in UTC.