### PR TITLE
Print unversioned when built without version

### DIFF
--- a/cmd/aws-iam-authenticator/version.go
+++ b/cmd/aws-iam-authenticator/version.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+
 	goVersion "github.com/christopherhein/go-version"
 	"github.com/spf13/cobra"
 )
 
 var (
 	shortened  = false
-	version    = ""
+	version    = "unversioned"
 	commit     = ""
 	date       = ""
 	versionCmd = &cobra.Command{


### PR DESCRIPTION
If built with go build, instead of printing an empty version `{}`, print:
```
$ go build ./cmd/aws-iam-authenticator/... && ./aws-iam-authenticator version
{"Version":"unversioned"}
```

Otherwise it works the same:
```
make && ./dist/linux_amd64/aws-iam-authenticator version
...
{"Version":"git-a6f1789","Commit":"a6f178937a5fa1fa8cd420237531be256771285b"}
```