### PR TITLE
Adding micahhausler as reviewer and security contact

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - nckturner
 - mattlandis
 - christopherhein
+- micahhausler

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -14,3 +14,4 @@ mattmoyer
 nckturner
 mattlandis
 christopherhein
+micahhausler


### PR DESCRIPTION
* Micah is an official security contact for EKS so I'm
  adding him to the contacts in this repository.
* Additionally proposing adding Micah as a reviewer due to his
  knowledge of and interest in the project.