### PR TITLE
Using sigs.k8s.io domain instead of github.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/kubernetes-sigs/aws-iam-authenticator
+go_import_path: sigs.k8s.io/aws-iam-authenticator
 go:
   - 1.10.x
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: build
 
-GITHUB_REPO ?= github.com/kubernetes-sigs/aws-iam-authenticator
+GITHUB_REPO ?= sigs.k8s.io/aws-iam-authenticator
 GORELEASER := $(shell command -v goreleaser 2> /dev/null)
 
 .PHONY: build test format

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This means the `kubeconfig` is entirely public data and can be shared across all
 It may make sense to upload it to a trusted public location such as AWS S3.
 
 Make sure you have the `aws-iam-authenticator` binary installed.
-You can install it with `go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator`.
+You can install it with `go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator`.
 
 To authenticate, run `kubectl --kubeconfig /path/to/kubeconfig" [...]`.
 kubectl will `exec` the `aws-iam-authenticator` binary with the supplied params in your kubeconfig which will generate a token and pass it to the apiserver.

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/server"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/server"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/aws-iam-authenticator/verify.go
+++ b/cmd/aws-iam-authenticator/verify.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,9 +28,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/arn"
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,9 +13,9 @@ import (
 
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
 	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 )
 
 func verifyBodyContains(t *testing.T, resp *httptest.ResponseRecorder, s string) {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package server
 
 import (
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 )
 
 // Server for the authentication webhook.

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -30,13 +29,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/arn"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientauthv1alpha1 "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
 )
 
 // Identity is returned on successful Verify() results. It contains a parsed


### PR DESCRIPTION
This updates all the imports to use `sigs.k8s.io/aws-iam-authenticator`. No major changes other than shortening the imports.

Signed-off-by: Christopher Hein <me@chrishein.com>

Closes #222