### PR TITLE
add support for passing externalID to assume role

### DIFF
--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -52,13 +52,12 @@ var tokenCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "could not get token: %v\n", err)
 			os.Exit(1)
 		}
-		if roleARN != "" {
-			// if a role was provided, assume that role for the token
-			tok, err = gen.GetWithRole(clusterID, roleARN, externalID)
-		} else {
-			// otherwise sign the token with immediately available credentials
-			tok, err = gen.Get(clusterID)
-		}
+
+		tok, err = gen.GetWithOptions(&token.GetTokenOptions{
+			ClusterID:            clusterID,
+			AssumeRoleARN:        roleARN,
+			AssumeRoleExternalID: externalID,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not get token: %v\n", err)
 			os.Exit(1)

--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -32,6 +32,7 @@ var tokenCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		roleARN := viper.GetString("role")
+		externalID := viper.GetString("externalID")
 		clusterID := viper.GetString("clusterID")
 		tokenOnly := viper.GetBool("tokenOnly")
 		forwardSessionName := viper.GetBool("forwardSessionName")
@@ -53,7 +54,7 @@ var tokenCmd = &cobra.Command{
 		}
 		if roleARN != "" {
 			// if a role was provided, assume that role for the token
-			tok, err = gen.GetWithRole(clusterID, roleARN)
+			tok, err = gen.GetWithRole(clusterID, roleARN, externalID)
 		} else {
 			// otherwise sign the token with immediately available credentials
 			tok, err = gen.Get(clusterID)
@@ -74,12 +75,14 @@ var tokenCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(tokenCmd)
 	tokenCmd.Flags().StringP("role", "r", "", "Assume an IAM Role ARN before signing this token")
+	tokenCmd.Flags().StringP("external-id", "e", "", "External ID to pass when assuming the IAM Role")
 	tokenCmd.Flags().Bool("token-only", false, "Return only the token for use with Bearer token based tools")
 	tokenCmd.Flags().Bool("forward-session-name",
 		false,
 		"Enable mapping a federated sessions caller-specified-role-name attribute onto newly assumed sessions. NOTE: Only applicable when a new role is requested via --role")
 	tokenCmd.Flags().Bool("cache", false, "Cache the credential on disk until it expires. Uses the aws profile specified by AWS_PROFILE or the default profile.")
 	viper.BindPFlag("role", tokenCmd.Flags().Lookup("role"))
+	viper.BindPFlag("externalID", tokenCmd.Flags().Lookup("external-id"))
 	viper.BindPFlag("tokenOnly", tokenCmd.Flags().Lookup("token-only"))
 	viper.BindPFlag("forwardSessionName", tokenCmd.Flags().Lookup("forward-session-name"))
 	viper.BindPFlag("cache", tokenCmd.Flags().Lookup("cache"))

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -90,6 +90,14 @@ type Token struct {
 	Expiration time.Time
 }
 
+// GetTokenOptions is passed to GetWithOptions to provide an extensible get token interface
+type GetTokenOptions struct {
+	ClusterID            string
+	AssumeRoleARN        string
+	AssumeRoleExternalID string
+	Session              *session.Session
+}
+
 // FormatError is returned when there is a problem with token that is
 // an encoded sts request.  This can include the url, data, action or anything
 // else that prevents the sts call from being made.
@@ -147,9 +155,11 @@ type Generator interface {
 	// Get a token using credentials in the default credentials chain.
 	Get(string) (Token, error)
 	// GetWithRole creates a token by assuming the provided role, using the credentials in the default chain.
-	GetWithRole(clusterID, roleARN string, externalID string) (Token, error)
+	GetWithRole(clusterID, roleARN string) (Token, error)
 	// GetWithRoleForSession creates a token by assuming the provided role, using the provided session.
-	GetWithRoleForSession(clusterID string, roleARN string, externalID string, sess *session.Session) (Token, error)
+	GetWithRoleForSession(clusterID string, roleARN string, sess *session.Session) (Token, error)
+	// Get a token using the provided options
+	GetWithOptions(options *GetTokenOptions) (Token, error)
 	// GetWithSTS returns a token valid for clusterID using the given STS client.
 	GetWithSTS(clusterID string, stsAPI *sts.STS) (Token, error)
 	// FormatJSON returns the client auth formatted json for the ExecCredential auth
@@ -172,7 +182,26 @@ func NewGenerator(forwardSessionName bool, cache bool) (Generator, error) {
 // Get uses the directly available AWS credentials to return a token valid for
 // clusterID. It follows the default AWS credential handling behavior.
 func (g generator) Get(clusterID string) (Token, error) {
-	return g.GetWithRole(clusterID, "", "")
+	return g.GetWithOptions(&GetTokenOptions{ClusterID: clusterID})
+}
+
+// GetWithRole assumes the given AWS IAM role and returns a token valid for
+// clusterID. If roleARN is empty, behaves like Get (does not assume a role).
+func (g generator) GetWithRole(clusterID string, roleARN string) (Token, error) {
+	return g.GetWithOptions(&GetTokenOptions{
+		ClusterID:     clusterID,
+		AssumeRoleARN: roleARN,
+	})
+}
+
+// GetWithRoleForSession assumes the given AWS IAM role for the given session and behaves
+// like GetWithRole.
+func (g generator) GetWithRoleForSession(clusterID string, roleARN string, sess *session.Session) (Token, error) {
+	return g.GetWithOptions(&GetTokenOptions{
+		ClusterID:     clusterID,
+		AssumeRoleARN: roleARN,
+		Session:       sess,
+	})
 }
 
 func StdinStderrTokenProvider() (string, error) {
@@ -182,47 +211,57 @@ func StdinStderrTokenProvider() (string, error) {
 	return v, err
 }
 
-// GetWithRole assumes the given AWS IAM role and returns a token valid for
-// clusterID. If roleARN is empty, behaves like Get (does not assume a role).
-func (g generator) GetWithRole(clusterID string, roleARN string, externalID string) (Token, error) {
-	// create a session with the "base" credentials available
-	// (from environment variable, profile files, EC2 metadata, etc)
-	sess, err := session.NewSessionWithOptions(session.Options{
-		AssumeRoleTokenProvider: StdinStderrTokenProvider,
-		SharedConfigState:       session.SharedConfigEnable,
-	})
-	if err != nil {
-		return Token{}, fmt.Errorf("could not create session: %v", err)
-	}
-	if g.cache {
-		// figure out what profile we're using
-		var profile string
-		if v := os.Getenv("AWS_PROFILE"); len(v) > 0 {
-			profile = v
-		} else {
-			profile = session.DefaultSharedConfigProfile
-		}
-		// create a cacheing Provider wrapper around the Credentials
-		if cacheProvider, err := NewFileCacheProvider(clusterID, profile, roleARN, sess.Config.Credentials); err == nil {
-			sess.Config.Credentials = credentials.NewCredentials(&cacheProvider)
-		} else {
-			_, _ = fmt.Fprintf(os.Stderr, "unable to use cache: %v\n", err)
-		}
+// GetWithOptions takes a GetTokenOptions struct, builds the STS client, and wraps GetWithSTS.
+// If no session has been passed in options, it will build a new session. If an
+// AssumeRoleARN was passed in then assume the role for the session.
+func (g generator) GetWithOptions(options *GetTokenOptions) (Token, error) {
+	if options.ClusterID == "" {
+		return Token{}, fmt.Errorf("ClusterID is required")
 	}
 
-	return g.GetWithRoleForSession(clusterID, roleARN, externalID, sess)
-}
+	if options.Session == nil {
+		// create a session with the "base" credentials available
+		// (from environment variable, profile files, EC2 metadata, etc)
+		sess, err := session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: StdinStderrTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+		})
+		if err != nil {
+			return Token{}, fmt.Errorf("could not create session: %v", err)
+		}
 
-// GetWithRoleForSession assumes the given AWS IAM role for the given session and behaves
-// like GetWithRole.
-func (g generator) GetWithRoleForSession(clusterID string, roleARN string, externalID string, sess *session.Session) (Token, error) {
+		if g.cache {
+			// figure out what profile we're using
+			var profile string
+			if v := os.Getenv("AWS_PROFILE"); len(v) > 0 {
+				profile = v
+			} else {
+				profile = session.DefaultSharedConfigProfile
+			}
+			// create a cacheing Provider wrapper around the Credentials
+			if cacheProvider, err := NewFileCacheProvider(options.ClusterID, profile, options.AssumeRoleARN, sess.Config.Credentials); err == nil {
+				sess.Config.Credentials = credentials.NewCredentials(&cacheProvider)
+			} else {
+				_, _ = fmt.Fprintf(os.Stderr, "unable to use cache: %v\n", err)
+			}
+		}
+
+		options.Session = sess
+	}
+
 	// use an STS client based on the direct credentials
-	stsAPI := sts.New(sess)
+	stsAPI := sts.New(options.Session)
 
 	// if a roleARN was specified, replace the STS client with one that uses
 	// temporary credentials from that role.
-	if roleARN != "" {
-		var userIDParts []string
+	if options.AssumeRoleARN != "" {
+		var sessionSetters []func(*stscreds.AssumeRoleProvider)
+
+		if options.AssumeRoleExternalID != "" {
+			sessionSetters = append(sessionSetters, func(provider *stscreds.AssumeRoleProvider) {
+				provider.ExternalID = &options.AssumeRoleExternalID
+			})
+		}
 
 		if g.forwardSessionName {
 			// If the current session is already a federated identity, carry through
@@ -233,26 +272,23 @@ func (g generator) GetWithRoleForSession(clusterID string, roleARN string, exter
 				return Token{}, err
 			}
 
-			userIDParts = strings.Split(*resp.UserId, ":")
-		}
-
-		sessionSetter := func(provider *stscreds.AssumeRoleProvider) {
-			if externalID != "" {
-				provider.ExternalID = &externalID
-			}
+			userIDParts := strings.Split(*resp.UserId, ":")
 			if len(userIDParts) == 2 {
-				provider.RoleSessionName = userIDParts[1]
+				sessionSetters = append(sessionSetters, func(provider *stscreds.AssumeRoleProvider) {
+					provider.RoleSessionName = userIDParts[1]
+				})
 			}
+
 		}
 
 		// create STS-based credentials that will assume the given role
-		creds := stscreds.NewCredentials(sess, roleARN, sessionSetter)
+		creds := stscreds.NewCredentials(options.Session, options.AssumeRoleARN, sessionSetters...)
 
 		// create an STS API interface that uses the assumed role's temporary credentials
-		stsAPI = sts.New(sess, &aws.Config{Credentials: creds})
+		stsAPI = sts.New(options.Session, &aws.Config{Credentials: creds})
 	}
 
-	return g.GetWithSTS(clusterID, stsAPI)
+	return g.GetWithSTS(options.ClusterID, stsAPI)
 }
 
 // GetWithSTS returns a token valid for clusterID using the given STS client.


### PR DESCRIPTION
It is common practice to require an "external ID" when making cross-account calls to STS assume role. This adds an optional `"--external-id"`/`"-e"`argument to the token command. When included it is passed in the AssumeRoleProvider.

Issue: https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/209