### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ users:
         - "-i"
         - "CLUSTER_ID"
         - "-r"
-        - "ROLE_ARN"
+        - "REPLACE_ME_WITH_YOUR_ROLE_ARN"
   # no client certificate/key needed here!
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ users:
       args:
         - "token"
         - "-i"
-        - "CLUSTER_ID"
+        - "REPLACE_ME_WITH_YOUR_CLUSTER_ID"
         - "-r"
         - "REPLACE_ME_WITH_YOUR_ROLE_ARN"
   # no client certificate/key needed here!


### PR DESCRIPTION
Clarify `ROLE_ARN` in example is not a magic string but a placeholder for a user's role arn.