### PR TITLE
Rename prometheus metrics to match new project name

### DIFF
--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is an example of how to deploy Heptio Authenticator for AWS.
+# This is an example of how to deploy AWS IAM Authenticator.
 #
 # To use this, you'll at least need to edit the role ARNs in the ConfigMap. You
 # may also need to rework other bits to work in your cluster (e.g., node labels).

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -90,9 +90,9 @@ type metrics struct {
 	latency *prometheus.HistogramVec
 }
 
-// namespace for the heptio authenticators metrics
+// namespace for the AWS IAM Authenticator's metrics
 const (
-	metricNS        = "heptio_authenticator_aws"
+	metricNS        = "aws_iam_authenticator"
 	metricMalformed = "malformed_request"
 	metricInvalid   = "invalid_token"
 	metricSTSError  = "sts_error"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -130,7 +130,7 @@ type validateOpts struct {
 func checkHistogramSampleCount(t *testing.T, name string, actual, expected uint64) {
 	t.Helper()
 	if actual != expected {
-		t.Errorf("expected %d samples histogram heptio_authenticator_aws_authenticate_latency_seconds with labels %s but got %d", expected, name, actual)
+		t.Errorf("expected %d samples histogram aws_iam_authenticator_authenticate_latency_seconds with labels %s but got %d", expected, name, actual)
 	}
 }
 
@@ -141,7 +141,7 @@ func validateMetrics(t *testing.T, opts validateOpts) {
 		t.Fatalf("Unable to gather metrics to validate they are recorded")
 	}
 	for _, m := range metrics {
-		if strings.HasPrefix(m.GetName(), "heptio_authenticator_aws_authenticate_latency_seconds") {
+		if strings.HasPrefix(m.GetName(), "aws_iam_authenticator_authenticate_latency_seconds") {
 			var actualSuccess, actualMalformed, actualInvalid, actualUnknown, actualSTSError uint64
 			for _, metric := range m.GetMetric() {
 				if len(metric.Label) != 1 {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -150,7 +150,7 @@ type getCallerIdentityWrapper struct {
 	} `json:"GetCallerIdentityResponse"`
 }
 
-// Generator provides new tokens for the heptio authenticator.
+// Generator provides new tokens for the AWS IAM Authenticator.
 type Generator interface {
 	// Get a token using credentials in the default credentials chain.
 	Get(string) (Token, error)


### PR DESCRIPTION
While I was at it I updated a few other references to the old project name as well.

This is a breaking change to anyone using the prometheus metrics, so it should at least be clearly mentioned in the release notes.