### PR TITLE
Updating goreleaser yaml to fix deprecated options

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,25 +16,30 @@ builds:
       - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
 
 dockers:
-  - binary: aws-iam-authenticator
+  - binaries:
+     - aws-iam-authenticator
     dockerfile: Dockerfile.scratch
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-scratch"
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}"
-  - binary: aws-iam-authenticator
+  - binaries:
+     - aws-iam-authenticator
     dockerfile: Dockerfile.alpine-3.6
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-alpine-3.6"
-  - binary: aws-iam-authenticator
+  - binaries:
+     - aws-iam-authenticator
     dockerfile: Dockerfile.alpine-3.7
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-alpine-3.7"
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-alpine"
-  - binary: aws-iam-authenticator
+  - binaries:
+     - aws-iam-authenticator
     dockerfile: Dockerfile.debian-jessie
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-debian-jessie"
-  - binary: aws-iam-authenticator
+  - binaries:
+     - aws-iam-authenticator
     dockerfile: Dockerfile.debian-stretch
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-debian-stretch"
@@ -43,8 +48,9 @@ dockers:
 snapshot:
   name_template: "git-{{.ShortCommit}}"
 
-archive:
-  format: binary
+archives:
+  - id: bin
+    format: binary
 
 release:
   github:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 install:
-  - curl -s -L --retry 8 -o /tmp/goreleaser.tgz https://github.com/goreleaser/goreleaser/releases/download/v0.107.0/goreleaser_Linux_x86_64.tar.gz
+  - curl -s -L --retry 8 -o /tmp/goreleaser.tgz https://github.com/goreleaser/goreleaser/releases/download/v0.115.0/goreleaser_Linux_x86_64.tar.gz
   - tar -xzvf /tmp/goreleaser.tgz -C /tmp/
   - sudo mv /tmp/goreleaser /usr/local/bin
 


### PR DESCRIPTION
 archive and docker binary options have changed.

Fixes https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/251