### PR TITLE
Remove DNS-1123 validation of usernames and groups

### DIFF
--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -103,6 +103,15 @@ data:
         username: admin:{{SessionName}}
         groups:
         - system:masters
+      # map federated users in my "KubernetesUsers" role to users like
+      # "alice@example.com". SessionNameRaw is sourced from the same place as
+      # SessionName with the distinction that no transformation is performed
+      # on the value. For example an email addresses passed by an identity
+      # provider will not have the `@` replaced with a `-`.
+      - roleARN: arn:aws:iam::000000000000:role/KubernetesUsers
+        username: "{{SessionNameRaw}}"
+        groups:
+        - developers
       # each mapUsers entry maps an IAM role to a static username and set of groups
       mapUsers:
       # map user IAM user Alice in 000000000000 to user "alice" in "system:masters"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,7 +69,6 @@ var tokenReviewDenyJSON = func() []byte {
 // Pattern to match EC2 instance IDs
 var (
 	instanceIDPattern = regexp.MustCompile("^i-(\\w{8}|\\w{17})$")
-	dns1123Pattern    = regexp.MustCompile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
 )
 
 // server state (internal)
@@ -405,14 +404,9 @@ func (h *handler) renderTemplate(template string, identity *token.Identity) (str
 	}
 
 	template = strings.Replace(template, "{{AccountID}}", identity.AccountID, -1)
-
-	// usernames and groups must be a DNS-1123 hostname matching the regex
-	// "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
 	sessionName := strings.Replace(identity.SessionName, "@", "-", -1)
 	template = strings.Replace(template, "{{SessionName}}", sessionName, -1)
-	if !dns1123Pattern.MatchString(template) {
-		return "", fmt.Errorf("username or group is not a DNS-1123 hostname")
-	}
+	template = strings.Replace(template, "{{SessionNameRaw}}", identity.SessionName, -1)
 
 	return template, nil
 }


### PR DESCRIPTION
k8s doesn't require user or group names to be DNS-1123 labels so there isn't a need to enforce or transform these values to conform to that format.

To that end this PR removes the regexp check which validates DNS-1123 and removes the string replacement of `@`s in SessionName.

Also of note that the current regex is missing start and end of line anchors so the validation is only ensuring that a group or user contains a sub-string that is a valid DNS-1123 label.

The second change does have impacts on existing usage of the `{{SessionName}}` template value which could break rolebindings for users who are making use of this value and have email addresses for session names.

I see a few ways this could be addressed and am happy to update the PR to reflect a desired path for this.

* Liberal documentation updates to warn users of the change.
* Toggle the change on a server flag (something along the lines of `--legacy-session-name=true`)
* Creating a new template variable (`{{SessionNameRaw}}`) that doesn't do the replacement and leave the existing behavior for `{{SessionName}}` in place.

Related to #80 