### PR TITLE
Adding session name parameter to TokenGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ To authenticate, run `kubectl --kubeconfig /path/to/kubeconfig" [...]`.
 kubectl will `exec` the `aws-iam-authenticator` binary with the supplied params in your kubeconfig which will generate a token and pass it to the apiserver.
 The token is valid for 15 minutes (the shortest value AWS permits) and can be reused multiple times.
 
+You can also specify session name when generating the token by including `--session-name or -s` parameter. This parameter cannot be used along with `--forward-session-name`.
+
 You can also omit `-r ROLE_ARN` to sign the token with your existing credentials without assuming a dedicated role.
 This is useful if you want to authenticate as an IAM user directly or if you want to authenticate using an EC2 instance role or a federated role.
 

--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -36,10 +36,17 @@ var tokenCmd = &cobra.Command{
 		clusterID := viper.GetString("clusterID")
 		tokenOnly := viper.GetBool("tokenOnly")
 		forwardSessionName := viper.GetBool("forwardSessionName")
+		sessionName := viper.GetString("sessionName")
 		cache := viper.GetBool("cache")
 
 		if clusterID == "" {
 			fmt.Fprintf(os.Stderr, "Error: cluster ID not specified\n")
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		if forwardSessionName && sessionName != "" {
+			fmt.Fprintf(os.Stderr, "Error: cannot specify both --forward-session-name and --session-name parameter\n")
 			cmd.Usage()
 			os.Exit(1)
 		}
@@ -57,6 +64,7 @@ var tokenCmd = &cobra.Command{
 			ClusterID:            clusterID,
 			AssumeRoleARN:        roleARN,
 			AssumeRoleExternalID: externalID,
+			SessionName:          sessionName,
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not get token: %v\n", err)
@@ -75,6 +83,7 @@ func init() {
 	rootCmd.AddCommand(tokenCmd)
 	tokenCmd.Flags().StringP("role", "r", "", "Assume an IAM Role ARN before signing this token")
 	tokenCmd.Flags().StringP("external-id", "e", "", "External ID to pass when assuming the IAM Role")
+	tokenCmd.Flags().StringP("session-name", "s", "", "Session name to pass when assuming the IAM Role")
 	tokenCmd.Flags().Bool("token-only", false, "Return only the token for use with Bearer token based tools")
 	tokenCmd.Flags().Bool("forward-session-name",
 		false,
@@ -84,6 +93,7 @@ func init() {
 	viper.BindPFlag("externalID", tokenCmd.Flags().Lookup("external-id"))
 	viper.BindPFlag("tokenOnly", tokenCmd.Flags().Lookup("token-only"))
 	viper.BindPFlag("forwardSessionName", tokenCmd.Flags().Lookup("forward-session-name"))
+	viper.BindPFlag("sessionName", tokenCmd.Flags().Lookup("session-name"))
 	viper.BindPFlag("cache", tokenCmd.Flags().Lookup("cache"))
 	viper.BindEnv("role", "DEFAULT_ROLE")
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -95,6 +95,7 @@ type GetTokenOptions struct {
 	ClusterID            string
 	AssumeRoleARN        string
 	AssumeRoleExternalID string
+	SessionName          string
 	Session              *session.Session
 }
 
@@ -278,7 +279,10 @@ func (g generator) GetWithOptions(options *GetTokenOptions) (Token, error) {
 					provider.RoleSessionName = userIDParts[1]
 				})
 			}
-
+		} else if options.SessionName != "" {
+			sessionSetters = append(sessionSetters, func(provider *stscreds.AssumeRoleProvider) {
+				provider.RoleSessionName = options.SessionName
+			})
 		}
 
 		// create STS-based credentials that will assume the given role


### PR DESCRIPTION
Adding sessionName parameter to authenticator client. Clients can set different session name when using roles to authenticate to API Server.

Changes include, 
cmd/../token.go -> 
i) Adding new parameter to read the session name. 
ii) Added validation to say either forwardSessionName or sessionName can be used when using role but not both.

pkg/.../token.go -> 
i) Added SessionName to GetTokenOptions struct
ii) Setting session name when creating session object through role.

cr https://code.amazon.com/reviews/CR-14787523