### PR TITLE
Allow server port customization

### DIFF
--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -62,8 +62,6 @@ var serverCmd = &cobra.Command{
 }
 
 func init() {
-	viper.SetDefault("server.port", DefaultPort)
-
 	serverCmd.Flags().String("generate-kubeconfig",
 		"/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml",
 		"Output `path` where a generated webhook kubeconfig (for `--authentication-token-webhook-config-file`) will be stored (should be a hostPath mount).")
@@ -97,6 +95,12 @@ func init() {
 		[]string{mapper.ModeCRD, mapper.ModeConfigMap, mapper.ModeFile},
 		fmt.Sprintf("Ordered list of backends to get mappings from. The first one that returns a matching mapping wins. Comma-delimited list of: %s", strings.Join(mapper.BackendModeChoices, ",")))
 	viper.BindPFlag("server.backendMode", serverCmd.Flags().Lookup("backend-mode"))
+
+	serverCmd.Flags().Int(
+		"port",
+		DefaultPort,
+		"Port to bind the server to listen to")
+	viper.BindPFlag("server.port", serverCmd.Flags().Lookup("port"))
 
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	_ = fs.Parse([]string{})


### PR DESCRIPTION
I had to make this change to stop authenticator from binding to port `0` (unsure why). It preserves current behavior while making the port user-customizable.