### PR TITLE
Add AWS Access Key ID to log

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 by the contributors.
+Copyright 2017-2020 by the contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -294,10 +294,11 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 	}
 
 	log.WithFields(logrus.Fields{
-		"arn":       identity.ARN,
-		"accountid": identity.AccountID,
-		"userid":    identity.UserID,
-		"session":   identity.SessionName,
+		"accesskeyid": identity.AccessKeyID,
+		"arn":         identity.ARN,
+		"accountid":   identity.AccountID,
+		"userid":      identity.UserID,
+		"session":     identity.SessionName,
 	}).Info("STS response")
 
 	// look up the ARN in each of our mappings to fill in the username and groups

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -48,8 +48,8 @@ func assertSTSError(t *testing.T, err error) {
 var (
 	now        = time.Now()
 	timeStr    = now.UTC().Format("20060102T150405Z")
+	validURL   = fmt.Sprintf("https://sts.amazonaws.com/?action=GetCallerIdentity&X-Amz-Credential=ASIABCDEFGHIJKLMNOPQ%%2F20191216%%2Fus-west-2%%2Fs3%%2Faws4_request&x-amz-signedheaders=x-k8s-aws-id&x-amz-expires=60&x-amz-date=%s", timeStr)
 	validToken = toToken(validURL)
-	validURL   = fmt.Sprintf("https://sts.amazonaws.com/?action=GetCallerIdentity&x-amz-signedheaders=x-k8s-aws-id&x-amz-expires=60&x-amz-date=%s", timeStr)
 )
 
 func toToken(url string) string {
@@ -209,15 +209,19 @@ func TestVerifyNoSession(t *testing.T) {
 	arn := "arn:aws:iam::123456789012:user/Alice"
 	account := "123456789012"
 	userID := "Alice"
+	accessKeyID := "ASIABCDEFGHIJKLMNOPQ"
 	identity, err := newVerifier(200, jsonResponse(arn, account, userID), nil).Verify(validToken)
 	if err != nil {
 		t.Errorf("expected error to be nil was %q", err)
+	}
+	if identity.AccessKeyID != accessKeyID {
+		t.Errorf("expected AccessKeyID to be %q but was %q", accessKeyID, identity.AccessKeyID)
 	}
 	if identity.ARN != arn {
 		t.Errorf("expected ARN to be %q but was %q", arn, identity.ARN)
 	}
 	if identity.CanonicalARN != arn {
-		t.Errorf("expected CannonicalARN to be %q but was %q", arn, identity.CanonicalARN)
+		t.Errorf("expected CanonicalARN to be %q but was %q", arn, identity.CanonicalARN)
 	}
 	if identity.UserID != userID {
 		t.Errorf("expected Username to be %q but was %q", userID, identity.UserID)


### PR DESCRIPTION
Add the AWS Access Key ID to the STS response log.  This should make it
easier to audit the true identity of the user or process that
authenticated to the cluster.

Fixes #263.