### PR TITLE
Restrict ClusterRole to readonly IAMIdentityMapping access

### DIFF
--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -27,9 +27,18 @@ rules:
 - apiGroups:
   - iamauthenticator.k8s.aws
   resources:
-  - "*"
+  - iamidentitymappings
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iamauthenticator.k8s.aws
+  resources:
+  - iamidentitymappings/status
+  verbs:
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
In the spirit of least privilege security, we shouldn't give write access to the custom resources since it is not needed.