### PR TITLE
Adding Rate limiting ec2:DescribeInstances API along with Batching for high TPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ cscope.*
 
 # local dot files
 .envrc
+
+# coverage.out file
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ endif
 	$(GORELEASER) --skip-publish --rm-dist --snapshot
 
 test:
-	go test -v -cover -race $(GITHUB_REPO)/...
+	go test -v -coverprofile=coverage.out -race $(GITHUB_REPO)/...
+	go tool cover -html=coverage.out -o coverage.html
 
 format:
 	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -96,6 +96,8 @@ func getConfig() (config.Config, error) {
 		Kubeconfig:                        viper.GetString("server.kubeconfig"),
 		Master:                            viper.GetString("server.master"),
 		BackendMode:                       viper.GetStringSlice("server.backendMode"),
+		EC2DescribeInstancesQps:           viper.GetInt("server.ec2DescribeInstancesQps"),
+		EC2DescribeInstancesBurst:         viper.GetInt("server.ec2DescribeInstancesBurst"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &cfg.RoleMappings); err != nil {
 		return cfg, fmt.Errorf("invalid server role mappings: %v", err)

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -30,8 +30,13 @@ import (
 	"github.com/spf13/viper"
 )
 
-// DefaultPort is the default localhost port (chosen randomly).
-const DefaultPort = 21362
+const (
+	// DefaultPort is the default localhost port (chosen randomly).
+	DefaultPort = 21362
+	// Default Ec2 TPS Variables
+	DefaultEC2DescribeInstancesQps   = 15
+	DefaultEC2DescribeInstancesBurst = 5
+)
 
 // serverCmd represents the server command
 var serverCmd = &cobra.Command{
@@ -101,6 +106,18 @@ func init() {
 		DefaultPort,
 		"Port to bind the server to listen to")
 	viper.BindPFlag("server.port", serverCmd.Flags().Lookup("port"))
+
+	serverCmd.Flags().Int(
+		"ec2-describeInstances-qps",
+		DefaultEC2DescribeInstancesQps,
+		"AWS EC2 rate limiting with qps")
+	viper.BindPFlag("server.ec2DescribeInstancesQps", serverCmd.Flags().Lookup("ec2-describeInstances-qps"))
+
+	serverCmd.Flags().Int(
+		"ec2-describeInstances-burst",
+		DefaultEC2DescribeInstancesBurst,
+		"AWS EC2 rate Limiting with burst")
+	viper.BindPFlag("server.ec2DescribeInstancesBurst", serverCmd.Flags().Lookup("ec2-describeInstances-burst"))
 
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	_ = fs.Parse([]string{})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/aws-iam-authenticator
 
-go 1.12
+go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.26.7
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	go.hein.dev/go-version v0.1.0
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190425012535-181e1f9c52c1
 	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.23.11 h1:fTq1xdeDdCwUfBA64QHk1b5HJfWauac36LvtWlk0pEw=
-github.com/aws/aws-sdk-go v1.23.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.26.7 h1:ObjEnmzvSdYy8KVd3me7v/UMyCn81inLy2SyoIPoBkg=
 github.com/aws/aws-sdk-go v1.26.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -128,4 +128,9 @@ type Config struct {
 
 	// BackendMode is an ordered list of backends to get mappings from. Comma-delimited list of: File,ConfigMap,CRD
 	BackendMode []string
+
+	// Ec2 DescribeInstances rate limiting variables initially set to defaults until we completely
+	// understand we don't need to change
+	EC2DescribeInstancesQps   int
+	EC2DescribeInstancesBurst int
 }

--- a/pkg/ec2provider/ec2provider.go
+++ b/pkg/ec2provider/ec2provider.go
@@ -1,0 +1,275 @@
+package ec2provider
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/httputil"
+)
+
+const (
+	// max limit of k8s nodes support
+	maxChannelSize = 8000
+	// max number of in flight non batched ec2:DescribeInstances request to flow
+	maxAllowedInflightRequest = 5
+	// default wait interval for the ec2 instance id request which is already in flight
+	defaultWaitInterval = 50 * time.Millisecond
+	// Making sure the single instance calls waits max till 5 seconds 100* (50 * time.Millisecond)
+	totalIterationForWaitInterval = 100
+	// Maximum number of instances with which ec2:DescribeInstances call will be made
+	maxInstancesBatchSize = 100
+	// Maximum time in Milliseconds to wait for a new batch call this also depends on if the instance size has
+	// already become 100 then it will not respect this limit
+	maxWaitIntervalForBatch = 200
+)
+
+// Get a node name from instance ID
+type EC2Provider interface {
+	GetPrivateDNSName(string) (string, error)
+	StartEc2DescribeBatchProcessing()
+}
+
+type ec2PrivateDNSCache struct {
+	cache map[string]string
+	lock  sync.RWMutex
+}
+
+type ec2Requests struct {
+	set  map[string]bool
+	lock sync.RWMutex
+}
+
+type ec2ProviderImpl struct {
+	ec2                ec2iface.EC2API
+	privateDNSCache    ec2PrivateDNSCache
+	ec2Requests        ec2Requests
+	instanceIdsChannel chan string
+}
+
+func New(roleARN string, qps int, burst int) EC2Provider {
+	dnsCache := ec2PrivateDNSCache{
+		cache: make(map[string]string),
+		lock:  sync.RWMutex{},
+	}
+	ec2Requests := ec2Requests{
+		set:  make(map[string]bool),
+		lock: sync.RWMutex{},
+	}
+	return &ec2ProviderImpl{
+		ec2:                ec2.New(newSession(roleARN, qps, burst)),
+		privateDNSCache:    dnsCache,
+		ec2Requests:        ec2Requests,
+		instanceIdsChannel: make(chan string, maxChannelSize),
+	}
+}
+
+// Initial credentials loaded from SDK's default credential chain, such as
+// the environment, shared credentials (~/.aws/credentials), or EC2 Instance
+// Role.
+
+func newSession(roleARN string, qps int, burst int) *session.Session {
+	sess := session.Must(session.NewSession())
+	if aws.StringValue(sess.Config.Region) == "" {
+		ec2metadata := ec2metadata.New(sess)
+		regionFound, err := ec2metadata.Region()
+		if err != nil {
+			logrus.WithError(err).Fatal("Region not found in shared credentials, environment variable, or instance metadata.")
+		}
+		sess.Config.Region = aws.String(regionFound)
+	}
+
+	if roleARN != "" {
+		logrus.WithFields(logrus.Fields{
+			"roleARN": roleARN,
+		}).Infof("Using assumed role for EC2 API")
+
+		rateLimitedClient, err := httputil.NewRateLimitedClient(qps, burst)
+
+		if err != nil {
+			logrus.Errorf("Getting error = %s while creating rate limited client ", err)
+		}
+
+		ap := &stscreds.AssumeRoleProvider{
+			Client:   sts.New(sess, aws.NewConfig().WithHTTPClient(rateLimitedClient).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)),
+			RoleARN:  roleARN,
+			Duration: time.Duration(60) * time.Minute,
+		}
+
+		sess.Config.Credentials = credentials.NewCredentials(ap)
+	}
+	return sess
+}
+
+func (p *ec2ProviderImpl) setPrivateDNSNameCache(id string, privateDNSName string) {
+	p.privateDNSCache.lock.Lock()
+	defer p.privateDNSCache.lock.Unlock()
+	p.privateDNSCache.cache[id] = privateDNSName
+}
+
+func (p *ec2ProviderImpl) setRequestInFlightForInstanceId(id string) {
+	p.ec2Requests.lock.Lock()
+	defer p.ec2Requests.lock.Unlock()
+	p.ec2Requests.set[id] = true
+}
+
+func (p *ec2ProviderImpl) unsetRequestInFlightForInstanceId(id string) {
+	p.ec2Requests.lock.Lock()
+	defer p.ec2Requests.lock.Unlock()
+	delete(p.ec2Requests.set, id)
+}
+
+func (p *ec2ProviderImpl) getRequestInFlightForInstanceId(id string) bool {
+	p.ec2Requests.lock.RLock()
+	defer p.ec2Requests.lock.RUnlock()
+	_, ok := p.ec2Requests.set[id]
+	return ok
+}
+
+func (p *ec2ProviderImpl) getRequestInFlightSize() int {
+	p.ec2Requests.lock.RLock()
+	defer p.ec2Requests.lock.RUnlock()
+	length := len(p.ec2Requests.set)
+	return length
+}
+
+// GetPrivateDNS looks up the private DNS from the EC2 API
+func (p *ec2ProviderImpl) getPrivateDNSNameCache(id string) (string, error) {
+	p.privateDNSCache.lock.RLock()
+	defer p.privateDNSCache.lock.RUnlock()
+	name, ok := p.privateDNSCache.cache[id]
+	if ok {
+		return name, nil
+	}
+	return "", errors.New("instance id not found")
+}
+
+// Only calls API if its not in the cache
+func (p *ec2ProviderImpl) GetPrivateDNSName(id string) (string, error) {
+	privateDNSName, err := p.getPrivateDNSNameCache(id)
+	if err == nil {
+		return privateDNSName, nil
+	}
+	logrus.Debugf("Missed the cache for the InstanceId = %s Verifying if its already in requestQueue ", id)
+	// check if the request for instanceId already in queue.
+	if p.getRequestInFlightForInstanceId(id) {
+		logrus.Debugf("Found the InstanceId:= %s request In Queue waiting in 5 seconds loop ", id)
+		for i := 0; i < totalIterationForWaitInterval; i++ {
+			time.Sleep(defaultWaitInterval)
+			privateDNSName, err := p.getPrivateDNSNameCache(id)
+			if err == nil {
+				return privateDNSName, nil
+			}
+		}
+		return "", fmt.Errorf("failed to find node %s in PrivateDNSNameCache returning from loop", id)
+	}
+	logrus.Debugf("Missed the requestQueue cache for the InstanceId = %s", id)
+	p.setRequestInFlightForInstanceId(id)
+	requestQueueLength := p.getRequestInFlightSize()
+	//The code verifies if the requestQuqueMap size is greater than max request in flight with rate
+	//limiting then writes to the channel where we are making batch ec2:DescribeInstances API call.
+	if requestQueueLength > maxAllowedInflightRequest {
+		logrus.Debugf("Writing to buffered channel for instance Id %s ", id)
+		p.instanceIdsChannel <- id
+		return p.GetPrivateDNSName(id)
+	}
+
+	logrus.Infof("Calling ec2:DescribeInstances for the InstanceId = %s ", id)
+	// Look up instance from EC2 API
+	output, err := p.ec2.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice([]string{id}),
+	})
+	if err != nil {
+		p.unsetRequestInFlightForInstanceId(id)
+		return "", fmt.Errorf("failed querying private DNS from EC2 API for node %s: %s ", id, err.Error())
+	}
+	for _, reservation := range output.Reservations {
+		for _, instance := range reservation.Instances {
+			if aws.StringValue(instance.InstanceId) == id {
+				privateDNSName = aws.StringValue(instance.PrivateDnsName)
+				p.setPrivateDNSNameCache(id, privateDNSName)
+				p.unsetRequestInFlightForInstanceId(id)
+			}
+		}
+	}
+
+	if privateDNSName == "" {
+		return "", fmt.Errorf("failed to find node %s ", id)
+	}
+	return privateDNSName, nil
+}
+
+func (p *ec2ProviderImpl) StartEc2DescribeBatchProcessing() {
+	startTime := time.Now()
+	var instanceIdList []string
+	for {
+		var instanceId string
+		select {
+		case instanceId = <-p.instanceIdsChannel:
+			logrus.Debugf("Received the Instance Id := %s from buffered Channel for batch processing ", instanceId)
+			instanceIdList = append(instanceIdList, instanceId)
+		default:
+			// Waiting for more elements to get added to the buffered Channel
+			// And to support the for select loop.
+			time.Sleep(20 * time.Millisecond)
+		}
+		endTime := time.Now()
+		/*
+			The if statement checks for empty list and ignores to make any ec2:Describe API call
+			If elements are less than 100 and time of 200 millisecond has elapsed it will make the
+			ec2:DescribeInstances call with as many elements in the list.
+			It is also possible that if the system gets more than 99 elements in the list in less than
+			200 milliseconds time it will the ec2:DescribeInstances call and that's our whole point of
+			optimization here. Also for FYI we have client level rate limiting which is what this
+			ec2:DescribeInstances call will make so this call is also rate limited.
+		*/
+		if (len(instanceIdList) > 0 && (endTime.Sub(startTime).Milliseconds()) > maxWaitIntervalForBatch) || len(instanceIdList) > maxInstancesBatchSize {
+			startTime = time.Now()
+			dupInstanceList := make([]string, len(instanceIdList))
+			copy(dupInstanceList, instanceIdList)
+			go p.getPrivateDnsAndPublishToCache(dupInstanceList)
+			instanceIdList = nil
+		}
+	}
+}
+
+func (p *ec2ProviderImpl) getPrivateDnsAndPublishToCache(instanceIdList []string) {
+	// Look up instance from EC2 API
+	logrus.Infof("Making Batch Query to DescribeInstances for %v instances ", len(instanceIdList))
+	output, err := p.ec2.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice(instanceIdList),
+	})
+	if err != nil {
+		logrus.Errorf("Batch call failed querying private DNS from EC2 API for nodes [%s] : with error = []%s ", instanceIdList, err.Error())
+	} else {
+		if output.NextToken != nil {
+			logrus.Debugf("Successfully got the batch result , output.NextToken = %s ", *output.NextToken)
+		} else {
+			logrus.Debugf("Successfully got the batch result , output.NextToken is nil ")
+		}
+		// Adding the result to privateDNSChache as well as removing from the requestQueueMap.
+		for _, reservation := range output.Reservations {
+			for _, instance := range reservation.Instances {
+				id := aws.StringValue(instance.InstanceId)
+				privateDNSName := aws.StringValue(instance.PrivateDnsName)
+				p.setPrivateDNSNameCache(id, privateDNSName)
+			}
+		}
+	}
+
+	logrus.Debugf("Removing instances from request Queue after getting response from Ec2")
+	for _, id := range instanceIdList {
+		p.unsetRequestInFlightForInstanceId(id)
+	}
+}

--- a/pkg/ec2provider/ec2provider_test.go
+++ b/pkg/ec2provider/ec2provider_test.go
@@ -1,0 +1,148 @@
+package ec2provider
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	DescribeDelay = 100
+)
+
+type mockEc2Client struct {
+	ec2iface.EC2API
+	Reservations []*ec2.Reservation
+}
+
+func (c *mockEc2Client) DescribeInstances(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	// simulate the time it takes for aws to return
+	time.Sleep(DescribeDelay * time.Millisecond)
+	var reservations []*ec2.Reservation
+	for _, res := range c.Reservations {
+		var reservation ec2.Reservation
+		for _, inst := range res.Instances {
+			for _, id := range in.InstanceIds {
+				if aws.StringValue(id) == aws.StringValue(inst.InstanceId) {
+					reservation.Instances = append(reservation.Instances, inst)
+				}
+			}
+		}
+		if len(reservation.Instances) > 0 {
+			reservations = append(reservations, &reservation)
+		}
+	}
+	return &ec2.DescribeInstancesOutput{
+		Reservations: reservations,
+	}, nil
+}
+
+func newMockedEC2ProviderImpl() *ec2ProviderImpl {
+	dnsCache := ec2PrivateDNSCache{
+		cache:     make(map[string]string),
+		lock: sync.RWMutex{},
+	}
+	ec2Requests := ec2Requests{
+		set:  make(map[string]bool),
+		lock: sync.RWMutex{},
+	}
+	return &ec2ProviderImpl{
+		ec2:                &mockEc2Client{},
+		privateDNSCache:    dnsCache,
+		ec2Requests:       ec2Requests,
+		instanceIdsChannel: make(chan string, maxChannelSize),
+	}
+
+}
+
+func TestGetPrivateDNSName(t *testing.T) {
+	ec2Provider := newMockedEC2ProviderImpl()
+	ec2Provider.ec2 = &mockEc2Client{Reservations: prepareSingleInstanceOutput()}
+	go ec2Provider.StartEc2DescribeBatchProcessing()
+	dns_name, err := ec2Provider.GetPrivateDNSName("ec2-1")
+	if err != nil {
+		t.Error("There is an error which is not expected when calling ec2 API with setting up mocks")
+	}
+	if dns_name != "ec2-dns-1" {
+		t.Errorf("want: %v, got: %v", "ec2-dns-1", dns_name)
+	}
+}
+
+func prepareSingleInstanceOutput() []*ec2.Reservation {
+	reservations := []*ec2.Reservation{
+		{
+			Groups: nil,
+			Instances: []*ec2.Instance{
+				&ec2.Instance{
+					InstanceId:     aws.String("ec2-1"),
+					PrivateDnsName: aws.String("ec2-dns-1"),
+				},
+			},
+			OwnerId:       nil,
+			RequesterId:   nil,
+			ReservationId: nil,
+		},
+	}
+	return reservations
+}
+
+func TestGetPrivateDNSNameWithBatching(t *testing.T) {
+	ec2Provider := newMockedEC2ProviderImpl()
+	reservations := prepare100InstanceOutput()
+	ec2Provider.ec2 = &mockEc2Client{Reservations: reservations}
+	go ec2Provider.StartEc2DescribeBatchProcessing()
+	var wg sync.WaitGroup
+	for i := 1; i < 101; i++ {
+		instanceString := "ec2-" + strconv.Itoa(i)
+		dnsString := "ec2-dns-" + strconv.Itoa(i)
+		wg.Add(1)
+		// This code helps test the batch functionality twice
+		if i == 50 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		go getPrivateDNSName(ec2Provider, instanceString, dnsString, t, &wg)
+	}
+	wg.Wait()
+}
+
+func getPrivateDNSName(ec2provider *ec2ProviderImpl, instanceString string, dnsString string, t *testing.T, wg *sync.WaitGroup) {
+	defer wg.Done()
+	dnsName, err := ec2provider.GetPrivateDNSName(instanceString)
+	if err != nil {
+		t.Error("There is an error which is not expected when calling ec2 API with setting up mocks")
+	}
+	if dnsName != dnsString {
+		t.Errorf("want: %v, got: %v", dnsString, dnsName)
+	}
+}
+
+func prepare100InstanceOutput() []*ec2.Reservation {
+
+	var reservations []*ec2.Reservation
+
+	for i := 1; i < 101; i++ {
+		instanceString := "ec2-" + strconv.Itoa(i)
+		dnsString := "ec2-dns-" + strconv.Itoa(i)
+		instance := &ec2.Instance{
+			InstanceId:     aws.String(instanceString),
+			PrivateDnsName: aws.String(dnsString),
+		}
+		var instances []*ec2.Instance
+		instances = append(instances, instance)
+		res1 := &ec2.Reservation{
+			Groups:        nil,
+			Instances:     instances,
+			OwnerId:       nil,
+			RequesterId:   nil,
+			ReservationId: nil,
+		}
+		reservations = append(reservations, res1)
+	}
+	return reservations
+
+}

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -1,0 +1,37 @@
+// Package httputil implements HTTP utilities.
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+
+	"golang.org/x/time/rate"
+)
+
+// NewRateLimitedClient returns a new HTTP client with rate limiter.
+func NewRateLimitedClient(qps int, burst int) (*http.Client, error) {
+	if qps == 0 {
+		return http.DefaultClient, nil
+	}
+	if burst < 1 {
+		return nil, fmt.Errorf("burst expected >0, got %d", burst)
+	}
+	return &http.Client{
+		Transport: &rateLimitedRoundTripper{
+			rt: http.DefaultTransport,
+			rl: rate.NewLimiter(rate.Limit(qps), burst),
+		},
+	}, nil
+}
+
+type rateLimitedRoundTripper struct {
+	rt http.RoundTripper
+	rl *rate.Limiter
+}
+
+func (rr *rateLimitedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := rr.rl.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	return rr.rt.RoundTrip(req)
+}

--- a/pkg/httputil/client_test.go
+++ b/pkg/httputil/client_test.go
@@ -1,0 +1,130 @@
+package httputil
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewRateLimitedClient(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test", testHandler)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	u := ts.URL + "/test"
+
+	// requests are to be throttled if qps*burst < reqs
+	// estimated time: reqs / (qps*burst) seconds
+	tbs := []struct {
+		ctxTimeout time.Duration
+		qps        int
+		burst      int
+		reqs       int // concurrent requests
+		err        string
+	}{
+		{
+			qps:   1,
+			burst: 1,
+			reqs:  5,
+		},
+		{
+			qps:   10,
+			burst: 1,
+			reqs:  10,
+		},
+		{
+			// 20 concurrent encrypt requests should exceed 1 QPS before 10ms
+			// thus rate limiter returns an error
+			ctxTimeout: 10 * time.Millisecond,
+			qps:        1,
+			burst:      1,
+			reqs:       20,
+			err:        `context deadline`,
+			// "Wait(n=1) would exceed context deadline" for requests before timeout
+			// "context deadline exceeded" for requests after timeout
+		},
+	}
+	for idx, tt := range tbs {
+		cli, err := NewRateLimitedClient(tt.qps, tt.burst)
+		if err != nil {
+			t.Fatalf("#%d: failed to create a new client (%v)", idx, err)
+		}
+
+		now := time.Now()
+
+		errc := make(chan error, tt.reqs)
+		for i := 0; i < tt.reqs; i++ {
+			go func() {
+				var ctx context.Context
+				if tt.ctxTimeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(context.TODO(), tt.ctxTimeout)
+					defer cancel()
+				} else {
+					ctx = context.TODO()
+				}
+				req, err := http.NewRequest(http.MethodGet, u, nil)
+				if err != nil {
+					errc <- err
+					return
+				}
+				_, err = cli.Do(req.WithContext(ctx))
+				errc <- err
+			}()
+		}
+
+		failed := false
+		for i := 0; i < tt.reqs; i++ {
+			err = <-errc
+			switch {
+			case tt.err == "": // expects no error
+				if err != nil {
+					t.Errorf("#%d-%d: unexpected error %v", idx, i, err)
+				}
+			case tt.err != "": // expects error
+				if err == nil {
+					continue
+				}
+				if !strings.Contains(err.Error(), tt.err) &&
+					// TODO: why does this happen even when ctx is not canceled
+					// ref. https://github.com/golang/go/issues/36848
+					!strings.Contains(err.Error(), "i/o timeout") {
+					t.Errorf("#%d-%d: expected %q, got %v", idx, i, tt.err, err)
+				}
+				failed = true
+			}
+		}
+
+		if tt.err != "" && !failed {
+			t.Fatalf("#%d: expected failure %q, got no error", idx, tt.err)
+		}
+
+		if tt.err == "" {
+			took := time.Since(now)
+			expectedTook := time.Duration(0)
+			if tt.qps*tt.burst < tt.reqs {
+				expectedTook = time.Duration(tt.reqs/(tt.qps*tt.burst)) * time.Second
+				// bursty requests may be served concurrently
+				expectedTook /= 2
+			}
+			if expectedTook > 0 && took < expectedTook {
+				t.Fatalf("with rate limit, requests expected took %v, got %v", expectedTook, took)
+			}
+		}
+	}
+}
+
+func testHandler(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case "GET":
+		fmt.Fprint(w, `test`)
+	default:
+		http.Error(w, "Method Not Allowed", 405)
+	}
+}


### PR DESCRIPTION
## Prerequisite:
The AWS ec2:DescribeInstances API  is a low TPS batching capable API.

## Summary :
As of Today a K8s cluster can support up-to 5000 nodes. every nodes has to run kubelet process to join to cluster, while joining the cluster kubelet makes multiple calls to API Server and if it fails it does a retry with backoff where it can make 8-9 calls per object type per second.

Given the Authenticator is a webhook and API Server makes calls to Authenticator for every API call being made to verify the users or nodes role.

While verifying for nodes it needs to call to ec:DescribeInstances to get the PrivateDNSName for the node. When we make call to verify token and get-caller-identity we know about the instanceId. PrivateDNSName and whether the session is valid but we don't know whether this node belongs to the same aws account. 

## Problem:

For example lets assume we have 500 nodes , and a cluster have 20 object types.

Thinking of two situations:
- When Master restarts or new Master comes up and old master goes down in a HA Master setup
- When cluster has a sudden hike in number of nodes joining 

For the master restart , every connection to the old master from every kubelet running on nodes will close like watches and all hence kubelet will try to re-connect and get the updated list and do watch connection while doing so it has to pass through Authenticator and authenticator does verification of instance with PrivateDNSNames belonging to the same aws account.

As of today not having any rate limiting  for the ec2:DescribeInstances make service unavailable as after 20-30 calls the aws ec2 API starts throttling because every node calls goes to API in the same interval and at multiple fold.

The number of calls per second for the failed to get authenticated would be  

Number of nodes  * 20 * 8 = 500 * 20 * 8 = ~ 8000  TPS

In a minute it can go upto ~ 200 K - ~400K 

As this throttling would not get resolved at the same time it takes almost 2-5 minutes to get resolve 

So total number of throttling goes to a very high number which impacts other services running in the aws account or CNI or Kube-Controller-manager.

While the Authenticator tries to cache the PrivateDNSNames but that does not help in this case as the kubelet calls very fast and the master has restarted  so it does not have every node in cache.

## Solution:

1.  Adding rate Limiting to make sure it does not hit the high TPS
2. Adding rate limit will make the system very slow in the above mentioned situations as for the same node it would still make calls to ec2:DescribeInstances. So adding a look up map to check if we already have the in flight request for the ec2 instanceId and then wait for upto 5 second and keep looking into the cache to check if the Inflight request has completed and added the PrivateDNSName to cache.
3. Given having a large number of nodes it can still take minutes to process every single node description so adding a batching routine which when number of Inflight request becomes more than 5 it can start batching and every 200 milliseconds batches the instances and just makes one call to ec2 to get the details of instances and put the PrivateDNSNames into the cache.


## Testing:

- Added unit tests which emulates the behavior with 100 nodes. 
- Tested in a real EKS cluster with 500, 1000 and 3000 nodes to check the count of API as well as overall performance  of the system when we recycle the  masters. 

## Next:
- Adding Backoff Retry for AWS API ec2:DescribeInstances 


  





 
 




 