### PR TITLE
chown aws-iam-authenticator to avoid permission denied

### DIFF
--- a/Dockerfile.alpine-3.6
+++ b/Dockerfile.alpine-3.6
@@ -16,5 +16,6 @@ FROM alpine:3.6
 RUN adduser -D -u 10000 aws-iam-authenticator
 RUN apk add --update ca-certificates
 COPY aws-iam-authenticator /
+RUN chown aws-iam-authenticator /aws-iam-authenticator
 USER aws-iam-authenticator
 ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.alpine-3.7
+++ b/Dockerfile.alpine-3.7
@@ -16,5 +16,6 @@ FROM alpine:3.7
 RUN adduser -D -u 10000 aws-iam-authenticator
 RUN apk add --update ca-certificates
 COPY aws-iam-authenticator /
+RUN chown aws-iam-authenticator /aws-iam-authenticator
 USER aws-iam-authenticator
 ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.amazonlinux-2
+++ b/Dockerfile.amazonlinux-2
@@ -21,5 +21,6 @@ RUN yum install -y shadow-utils && \
     aws-iam-authenticator && \
     yum update -y
 COPY aws-iam-authenticator /
+RUN chown aws-iam-authenticator /aws-iam-authenticator
 USER aws-iam-authenticator
 ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.debian-jessie
+++ b/Dockerfile.debian-jessie
@@ -24,5 +24,6 @@ RUN adduser \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 COPY aws-iam-authenticator /
+RUN chown aws-iam-authenticator /aws-iam-authenticator
 USER aws-iam-authenticator
 ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.debian-stretch
+++ b/Dockerfile.debian-stretch
@@ -24,5 +24,6 @@ RUN adduser \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 COPY aws-iam-authenticator /
+RUN chown aws-iam-authenticator /aws-iam-authenticator
 USER aws-iam-authenticator
 ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -15,10 +15,12 @@
 FROM alpine:latest
 RUN adduser -D -u 10000 aws-iam-authenticator
 RUN apk add --update ca-certificates
+COPY aws-iam-authenticator /
+RUN chown aws-iam-authenticator /aws-iam-authenticator
 
 FROM scratch
 COPY --from=0 /etc/passwd /etc/passwd
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY aws-iam-authenticator /
+COPY --from=0 /aws-iam-authenticator /aws-iam-authenticator
 USER aws-iam-authenticator
 ENTRYPOINT ["/aws-iam-authenticator"]


### PR DESCRIPTION
Fixing the issue in #301 in a less controversial way :)

go builds binaries with permissions like so:
```
$ ls -la dist/goreleaserdocker010310734/aws-iam-authenticator 
-rwx------. 7 fedora fedora 38055936 Mar 13 20:39 dist/goreleaserdocker010310734/aws-iam-authenticator*
```
and user 10000/aws-iam-authenticator then gets permission denied when trying to run it:
```
$ make build
...
$ docker run 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.0-debian-stretch
standard_init_linux.go:211: exec user process caused "permission denied"
```
After these changes the containers work as expected,
```
$ make build
...
$ 
docker run 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.0-debian-stretch
A tool to authenticate to Kubernetes using AWS IAM credentials
...
```