### PR TITLE
Fix CRD mapper blocking all others because caches never sync  and revamp backend-mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ systemctl restart kubelet.service
 
 ### 4. Create IAM role/user to kubernetes user/group mappings
 The default behavior of the server is to source mappings exclusively from the
-`mapUsers` and `mapRoles` fields of its configuration. See [Full Configuration
-Format](#full-configuration-format) below for details.
+`mapUsers` and `mapRoles` fields of its configuration file. See [Full
+Configuration Format](#full-configuration-format) below for details.
 
 Using the `--backend-mode` flag, you can configure the server to source
 mappings from two additional backends: an EKS-style ConfigMap
@@ -116,6 +116,9 @@ This is the default backend of mappings and sufficient for most users. See
 This backend models each IAM mapping as an `IAMIdentityMapping` [Kubernetes
 Custom
 Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+This approach enables you to maintain mappings in a Kubernetes-native way using
+kubectl or the API. Plus, syntax errors (like misaligned YAML) can be more
+easily caught and won't affect all mappings.
 
 To setup an `IAMIdentityMapping` CRD you'll first need to `apply` the CRD
 manifest:

--- a/README.md
+++ b/README.md
@@ -82,17 +82,42 @@ You may also need to restart the kubelet daemon on your master node to pick up t
 systemctl restart kubelet.service
 ```
 
-### Configure IAMIdentityMapping Custom Resource Definitions
+### 4. Create IAM role/user to kubernetes user/group mappings
+The default behavior of the server is to source mappings exclusively from the
+`mapUsers` and `mapRoles` fields of its configuration. See [Full Configuration
+Format](#full-configuration-format) below for details.
 
-In the `master` version of the AWS IAM Authenticator you can configure your users using one of three methods. The `mapUsers` and `mapRoles` as seen in the [Full Configuration Format](#full-configuration-format), using the new (alpha) [Kubernetes Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), or using an [EKS aws-auth ConfigMap](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html). The `--backend-mode` flag determines which of these methods is enabled and their order of precedence (first match wins). The CRD and ConfigMap allow the authenticator server to update its IAM identity mappings without restarting. See [Issues #79](https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/79) for more details.
+Using the `--backend-mode` flag, you can configure the server to source
+mappings from two additional backends: an EKS-style ConfigMap
+(`--backend-mode=EKSConfigMap`) or `IAMIdentityMapping` custom resources
+(`--backend-mode=CRD`). The default backend, the server configuration ConfigMap
+that's mounted by the server pod, corresponds to
+`--backend-mode=MountedConfigMap`. You can pass a comma-separated list of these
+backends to have the server search them in order. For example, with
+`--backend-mode=EKSConfigMap,MountedConfigMap`, the server will search the
+EKS-style ConfigMap for a mapping then the server configuration ConfigMap if it
+doesn't find one. This is useful if you're migrating your mappings from one
+backend to another.
 
-To setup an `IAMIdentityMapping` CRD you'll first need to `apply` the CRD manifest:
+#### `MountedConfigMap`
+This is the default backend of mappings and sufficient for most users. See
+[Full Configuration Format](#full-configuration-format) below for details.
+
+#### `CRD` (alpha)
+This backend models each IAM mapping as an `IAMIdentityMapping` [Kubernetes
+Custom
+Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+
+To setup an `IAMIdentityMapping` CRD you'll first need to `apply` the CRD
+manifest:
 
 ```
 kubectl apply -f deploy/iamidentitymapping.yaml
 ```
 
-With the CRDs deployed you can then create Custom Resources which model your IAM Identities see [`./deploy/example-iamidentitymapping.yaml`](deploy/example-iamidentitymapping.yaml) :
+With the CRDs deployed you can then create Custom Resources which model your
+IAM Identities. See
+[`./deploy/example-iamidentitymapping.yaml`](deploy/example-iamidentitymapping.yaml):
 
 ```
 ---
@@ -113,7 +138,15 @@ spec:
   - system:masters
 ```
 
-### 4. Set up kubectl to use authentication tokens provided by AWS IAM Authenticator for Kubernetes
+#### `EKSConfigMap`
+The EKS-style `kube-system/aws-auth` ConfigMap serves as the backend. The
+ConfigMap is expected to be in exactly the same format as in EKS clusters:
+https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html. This is
+useful if you're migrating from/to EKS and want to keep your mappings, or are
+running EKS in addition to some other AWS cluster(s) and want to have the same
+mappings in each.
+
+### 5. Set up kubectl to use authentication tokens provided by AWS IAM Authenticator for Kubernetes
 
 > This requires a 1.10+ `kubectl` binary to work. If you receive `Please enter Username:` when trying to use `kubectl` you need to update to the latest `kubectl`
 
@@ -407,6 +440,9 @@ server:
   - "012345678901"
   - "456789012345"
 
+  # source mappings from this ConfigMap (mapUsers, mapRoles, & mapAccounts)
+  backendMode:
+  - MountedConfigMap
 ```
 
 ## Community, discussion, contribution, and support

--- a/README.md
+++ b/README.md
@@ -90,16 +90,25 @@ Format](#full-configuration-format) below for details.
 Using the `--backend-mode` flag, you can configure the server to source
 mappings from two additional backends: an EKS-style ConfigMap
 (`--backend-mode=EKSConfigMap`) or `IAMIdentityMapping` custom resources
-(`--backend-mode=CRD`). The default backend, the server configuration ConfigMap
-that's mounted by the server pod, corresponds to
-`--backend-mode=MountedConfigMap`. You can pass a comma-separated list of these
-backends to have the server search them in order. For example, with
-`--backend-mode=EKSConfigMap,MountedConfigMap`, the server will search the
-EKS-style ConfigMap for a mapping then the server configuration ConfigMap if it
-doesn't find one. This is useful if you're migrating your mappings from one
-backend to another.
+(`--backend-mode=CRD`). The default backend, the server configuration file
+that's mounted by the server pod, corresponds to `--backend-mode=MountedFile`.
 
-#### `MountedConfigMap`
+You can pass a comma-separated list of these backends to have the server search
+them in order. For example, with `--backend-mode=EKSConfigMap,MountedFile`, the
+server will search the EKS-style ConfigMap for mappings then, if it doesn't
+find a mapping for the given IAM role/user, the server configuration file. If a
+mapping for the same IAM role/user exists in multiple backends, the server will
+use the mapping in the backend that occurs first in the comma-separated list.
+In this example, if a mapping is found in the EKS ConfigMap then it will be
+used whether or not a duplicate or conflicting mapping exists in the server
+configuration file.
+
+Note that when setting a single backend, the server will *only* source from
+that one and ignore the others even if they exist. For example, with
+`--backend-mode=CRD`, the server will *only* source from `IAMIdentityMappings`
+and ignore the mounted file and EKS ConfigMap.
+
+#### `MountedFile`
 This is the default backend of mappings and sufficient for most users. See
 [Full Configuration Format](#full-configuration-format) below for details.
 
@@ -440,9 +449,9 @@ server:
   - "012345678901"
   - "456789012345"
 
-  # source mappings from this ConfigMap (mapUsers, mapRoles, & mapAccounts)
+  # source mappings from this file (mapUsers, mapRoles, & mapAccounts)
   backendMode:
-  - MountedConfigMap
+  - MountedFile
 ```
 
 ## Community, discussion, contribution, and support

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 )
 
@@ -113,7 +112,7 @@ func getConfig() (config.Config, error) {
 		return cfg, errors.New("cluster ID cannot be empty")
 	}
 
-	if errs := validateBackendMode(cfg.BackendMode); len(errs) > 0 {
+	if errs := mapper.ValidateBackendMode(cfg.BackendMode); len(errs) > 0 {
 		return cfg, utilerrors.NewAggregate(errs)
 	}
 
@@ -130,21 +129,4 @@ func getLogFormatter() logrus.Formatter {
 	}
 
 	return &logrus.TextFormatter{FullTimestamp: true}
-}
-
-func validateBackendMode(modes []string) []error {
-	var errs []error
-
-	allowedModes := sets.NewString(mapper.BackendModeChoices...)
-	for _, mode := range modes {
-		if !allowedModes.Has(mode) {
-			errs = append(errs, fmt.Errorf("backend-mode %q is not a valid mode", mode))
-		}
-	}
-
-	if len(modes) != len(sets.NewString(modes...).List()) {
-		errs = append(errs, fmt.Errorf("backend-mode %q has duplicates", modes))
-	}
-
-	return errs
 }

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -100,7 +100,7 @@ func init() {
 	viper.BindPFlag("server.address", serverCmd.Flags().Lookup("address"))
 
 	serverCmd.Flags().StringSlice("backend-mode",
-		[]string{mapper.ModeMountedConfigMap},
+		[]string{mapper.ModeMountedFile},
 		fmt.Sprintf("Ordered list of backends to get mappings from. The first one that returns a matching mapping wins. Comma-delimited list of: %s", strings.Join(mapper.BackendModeChoices, ",")))
 	viper.BindPFlag("server.backendMode", serverCmd.Flags().Lookup("backend-mode"))
 

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -97,7 +97,7 @@ func init() {
 	viper.BindPFlag("server.address", serverCmd.Flags().Lookup("address"))
 
 	serverCmd.Flags().StringSlice("backend-mode",
-		[]string{mapper.ModeCRD, mapper.ModeConfigMap, mapper.ModeFile},
+		[]string{mapper.ModeFile},
 		fmt.Sprintf("Ordered list of backends to get mappings from. The first one that returns a matching mapping wins. Comma-delimited list of: %s", strings.Join(mapper.BackendModeChoices, ",")))
 	viper.BindPFlag("server.backendMode", serverCmd.Flags().Lookup("backend-mode"))
 

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -53,7 +53,10 @@ var serverCmd = &cobra.Command{
 			logrus.Fatalf("%s", err)
 		}
 
-		mappers := server.BuildMapperChain(cfg)
+		mappers, err := server.BuildMapperChain(cfg)
+		if err != nil {
+			logrus.Fatalf("failed to build mapper chain: %v", err)
+		}
 		for _, m := range mappers {
 			logrus.Infof("starting mapper %q", m.Name())
 			if err := m.Start(stopCh); err != nil {
@@ -97,7 +100,7 @@ func init() {
 	viper.BindPFlag("server.address", serverCmd.Flags().Lookup("address"))
 
 	serverCmd.Flags().StringSlice("backend-mode",
-		[]string{mapper.ModeFile},
+		[]string{mapper.ModeMountedConfigMap},
 		fmt.Sprintf("Ordered list of backends to get mappings from. The first one that returns a matching mapping wins. Comma-delimited list of: %s", strings.Join(mapper.BackendModeChoices, ",")))
 	viper.BindPFlag("server.backendMode", serverCmd.Flags().Lookup("backend-mode"))
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -126,7 +126,7 @@ type Config struct {
 	// +optional
 	Kubeconfig string
 
-	// BackendMode is an ordered list of backends to get mappings from. Comma-delimited list of: File,ConfigMap,CRD
+	// BackendMode is an ordered list of backends to get mappings from. Comma-delimited list of: MountedFile,EKSConfigMap,CRD
 	BackendMode []string
 
 	// Ec2 DescribeInstances rate limiting variables initially set to defaults until we completely

--- a/pkg/mapper/configmap/mapper.go
+++ b/pkg/mapper/configmap/mapper.go
@@ -22,7 +22,6 @@ func NewConfigMapMapper(cfg config.Config) (*ConfigMapMapper, error) {
 }
 
 func (m *ConfigMapMapper) Name() string {
-	// TODO refactor & rename this package to EKSConfigMap
 	return mapper.ModeEKSConfigMap
 }
 

--- a/pkg/mapper/configmap/mapper.go
+++ b/pkg/mapper/configmap/mapper.go
@@ -22,7 +22,8 @@ func NewConfigMapMapper(cfg config.Config) (*ConfigMapMapper, error) {
 }
 
 func (m *ConfigMapMapper) Name() string {
-	return mapper.ModeConfigMap
+	// TODO refactor & rename this package to EKSConfigMap
+	return mapper.ModeEKSConfigMap
 }
 
 func (m *ConfigMapMapper) Start(stopCh <-chan struct{}) error {

--- a/pkg/mapper/file/mapper.go
+++ b/pkg/mapper/file/mapper.go
@@ -57,7 +57,8 @@ func NewFileMapperWithMaps(
 }
 
 func (m *FileMapper) Name() string {
-	return mapper.ModeFile
+	// TODO refactor and rename this package to MountedConfigMap
+	return mapper.ModeMountedConfigMap
 }
 
 func (m *FileMapper) Start(_ <-chan struct{}) error {

--- a/pkg/mapper/file/mapper.go
+++ b/pkg/mapper/file/mapper.go
@@ -57,8 +57,8 @@ func NewFileMapperWithMaps(
 }
 
 func (m *FileMapper) Name() string {
-	// TODO refactor and rename this package to MountedConfigMap
-	return mapper.ModeMountedConfigMap
+	// TODO refactor and rename this package to MountedFile
+	return mapper.ModeMountedFile
 }
 
 func (m *FileMapper) Start(_ <-chan struct{}) error {

--- a/pkg/mapper/file/mapper.go
+++ b/pkg/mapper/file/mapper.go
@@ -57,7 +57,6 @@ func NewFileMapperWithMaps(
 }
 
 func (m *FileMapper) Name() string {
-	// TODO refactor and rename this package to MountedFile
 	return mapper.ModeMountedFile
 }
 

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	// Deprecated: use ModeMountedConfigMap instead
+	// Deprecated: use ModeMountedFile instead
 	ModeFile string = "File"
 	// Deprecated: use ModeEKSConfigMap instead
 	ModeConfigMap string = "ConfigMap"
 
-	ModeMountedConfigMap string = "MountedConfigMap"
+	ModeMountedFile string = "MountedFile"
 
 	ModeEKSConfigMap string = "EKSConfigMap"
 
@@ -23,12 +23,12 @@ const (
 )
 
 var (
-	ValidBackendModeChoices      = []string{ModeFile, ModeConfigMap, ModeMountedConfigMap, ModeEKSConfigMap, ModeCRD}
+	ValidBackendModeChoices      = []string{ModeFile, ModeConfigMap, ModeMountedFile, ModeEKSConfigMap, ModeCRD}
 	DeprecatedBackendModeChoices = map[string]string{
-		ModeFile:      ModeMountedConfigMap,
+		ModeFile:      ModeMountedFile,
 		ModeConfigMap: ModeEKSConfigMap,
 	}
-	BackendModeChoices = []string{ModeMountedConfigMap, ModeEKSConfigMap, ModeCRD}
+	BackendModeChoices = []string{ModeMountedFile, ModeEKSConfigMap, ModeCRD}
 )
 
 var ErrNotMapped = errors.New("ARN is not mapped")

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -2,17 +2,34 @@ package mapper
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 )
 
 const (
-	ModeFile      string = "File"
+	// Deprecated: use ModeMountedConfigMap instead
+	ModeFile string = "File"
+	// Deprecated: use ModeEKSConfigMap instead
 	ModeConfigMap string = "ConfigMap"
-	ModeCRD       string = "CRD"
+
+	ModeMountedConfigMap string = "MountedConfigMap"
+
+	ModeEKSConfigMap string = "EKSConfigMap"
+
+	ModeCRD string = "CRD"
 )
 
-var BackendModeChoices = []string{ModeFile, ModeConfigMap, ModeCRD}
+var (
+	ValidBackendModeChoices      = []string{ModeFile, ModeConfigMap, ModeMountedConfigMap, ModeEKSConfigMap, ModeCRD}
+	DeprecatedBackendModeChoices = map[string]string{
+		ModeFile:      ModeMountedConfigMap,
+		ModeConfigMap: ModeEKSConfigMap,
+	}
+	BackendModeChoices = []string{ModeMountedConfigMap, ModeEKSConfigMap, ModeCRD}
+)
 
 var ErrNotMapped = errors.New("ARN is not mapped")
 
@@ -22,4 +39,31 @@ type Mapper interface {
 	Start(stopCh <-chan struct{}) error
 	Map(canonicalARN string) (*config.IdentityMapping, error)
 	IsAccountAllowed(accountID string) bool
+}
+
+func ValidateBackendMode(modes []string) []error {
+	var errs []error
+
+	validModes := sets.NewString(ValidBackendModeChoices...)
+	for _, mode := range modes {
+		if !validModes.Has(mode) {
+			errs = append(errs, fmt.Errorf("backend-mode %q is not a valid mode", mode))
+		}
+	}
+
+	for _, mode := range modes {
+		if replacementMode, ok := DeprecatedBackendModeChoices[mode]; ok {
+			logrus.Warningf("warning: backend-mode %q is deprecated, use %q instead", mode, replacementMode)
+		}
+	}
+
+	if len(modes) != len(sets.NewString(modes...).List()) {
+		errs = append(errs, fmt.Errorf("backend-mode %q has duplicates", modes))
+	}
+
+	if len(modes) == 0 {
+		errs = append(errs, fmt.Errorf("at least one backend-mode must be specified"))
+	}
+
+	return errs
 }

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -57,7 +57,7 @@ func ValidateBackendMode(modes []string) []error {
 		}
 	}
 
-	if len(modes) != len(sets.NewString(modes...).List()) {
+	if len(modes) != sets.NewString(modes...).Len() {
 		errs = append(errs, fmt.Errorf("backend-mode %q has duplicates", modes))
 	}
 

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -15,7 +15,7 @@ func TestValidateBackendMode(t *testing.T) {
 		{
 			name: "valid backend mode",
 			cfg: config.Config{
-				BackendMode: []string{ModeMountedConfigMap, ModeEKSConfigMap, ModeCRD},
+				BackendMode: []string{ModeMountedFile, ModeEKSConfigMap, ModeCRD},
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestValidateBackendMode(t *testing.T) {
 		{
 			name: "duplicate backend mode",
 			cfg: config.Config{
-				BackendMode: []string{ModeMountedConfigMap, ModeMountedConfigMap},
+				BackendMode: []string{ModeMountedFile, ModeMountedFile},
 			},
 			wantErrs: true,
 		},

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -1,0 +1,59 @@
+package mapper
+
+import (
+	"testing"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+)
+
+func TestValidateBackendMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfg      config.Config
+		wantErrs bool
+	}{
+		{
+			name: "valid backend mode",
+			cfg: config.Config{
+				BackendMode: []string{ModeMountedConfigMap, ModeEKSConfigMap, ModeCRD},
+			},
+		},
+		{
+			name: "valid deprecated backend mode",
+			cfg: config.Config{
+				BackendMode: []string{ModeFile, ModeConfigMap},
+			},
+		},
+		{
+			name: "invalid backend mode",
+			cfg: config.Config{
+				BackendMode: []string{"ModeFoo"},
+			},
+			wantErrs: true,
+		},
+		{
+			name: "empty backend mode",
+			cfg: config.Config{
+				BackendMode: []string{},
+			},
+			wantErrs: true,
+		},
+		{
+			name: "duplicate backend mode",
+			cfg: config.Config{
+				BackendMode: []string{ModeMountedConfigMap, ModeMountedConfigMap},
+			},
+			wantErrs: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			errs := ValidateBackendMode(c.cfg.BackendMode)
+			if len(errs) > 0 && !c.wantErrs {
+				t.Errorf("wanted no errors but got: %v", errs)
+			} else if len(errs) == 0 && c.wantErrs {
+				t.Errorf("wanted errors but got none")
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -209,7 +209,7 @@ func BuildMapperChain(cfg config.Config) ([]mapper.Mapper, error) {
 		switch mode {
 		case mapper.ModeFile:
 			fallthrough
-		case mapper.ModeMountedConfigMap:
+		case mapper.ModeMountedFile:
 			fileMapper, err := file.NewFileMapper(cfg)
 			if err != nil {
 				return nil, fmt.Errorf("backend-mode %q creation failed: %v", mode, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -202,34 +202,38 @@ func createMetrics() metrics {
 	return m
 }
 
-func BuildMapperChain(cfg config.Config) []mapper.Mapper {
+func BuildMapperChain(cfg config.Config) ([]mapper.Mapper, error) {
 	modes := cfg.BackendMode
 	mappers := []mapper.Mapper{}
 	for _, mode := range modes {
 		switch mode {
 		case mapper.ModeFile:
+			fallthrough
+		case mapper.ModeMountedConfigMap:
 			fileMapper, err := file.NewFileMapper(cfg)
 			if err != nil {
-				logrus.Fatalf("backend-mode %q creation failed: %v", mode, err)
+				return nil, fmt.Errorf("backend-mode %q creation failed: %v", mode, err)
 			}
 			mappers = append(mappers, fileMapper)
 		case mapper.ModeConfigMap:
+			fallthrough
+		case mapper.ModeEKSConfigMap:
 			configMapMapper, err := configmap.NewConfigMapMapper(cfg)
 			if err != nil {
-				logrus.Fatalf("backend-mode %q creation failed: %v", mode, err)
+				return nil, fmt.Errorf("backend-mode %q creation failed: %v", mode, err)
 			}
 			mappers = append(mappers, configMapMapper)
 		case mapper.ModeCRD:
 			crdMapper, err := crd.NewCRDMapper(cfg)
 			if err != nil {
-				logrus.Fatalf("backend-mode %q creation failed: %v", mode, err)
+				return nil, fmt.Errorf("backend-mode %q creation failed: %v", mode, err)
 			}
 			mappers = append(mappers, crdMapper)
 		default:
-			logrus.Fatalf("backend-mode %q is not a valid mode", mode)
+			return nil, fmt.Errorf("backend-mode %q is not a valid mode", mode)
 		}
 	}
-	return mappers
+	return mappers, nil
 }
 
 func duration(start time.Time) float64 {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/297 and https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/288

Discovered in https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/297 and https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/288 that there is a bug where if you place backend-mode CRD before the other backends/mappers...the others never start. And we have CRD as default the first...(which seems in hindsight like quite an oversight since it never left "alpha" :]). So I consider this a critical bugfix. The fix is small and in the first commit.

Now this bug wouldn't exist in the first place if I explicitly maintained behavior from pre-0.5.0 by keeping `backend-mode` equal to `File` instead of implicitly trusting that the fallback logic for `backend-mode` was sound when it is not. This is the second commit.

Moreover, it seems there's consensus that the backend-mode flag is confusing and the README in*sufficient. `File` and `ConfigMap` are super confusing because both are files...and both are configmaps... So to remove ambiguity I've deprecated them and renamed backend `ConfigMap` to `EKSConfigMap` and `File` to `MountedConfigMap`. Open to other suggestions. These are the last 2 commits.

I've stopped short of refactoring the code (package `file` and package `configmap`) to match the new names because I don't want to risk more instability. But that can be done in the future if we get more sophisticated integration/e2e tests which are at the moment hard to write without infrastructure for deploying a kops cluster, etc.