### PR TITLE
Show log message when configmap can't be watched

### DIFF
--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -59,7 +59,7 @@ func (ms *MapStore) startLoadConfigMap(stopCh <-chan struct{}) {
 					FieldSelector: fields.OneTermEqualSelector("metadata.name", "aws-auth").String(),
 				})
 				if err != nil {
-					logrus.Warn("Unable to re-establish watch.  Sleeping for 5 seconds")
+					logrus.Warnf("Unable to re-establish watch: %v.  Sleeping for 5 seconds", err)
 					time.Sleep(5 * time.Second)
 					continue
 				}


### PR DESCRIPTION
I was running into issues setting this up in my cluster for the first time. It was extremely difficult to diagnose the cause without being able to see the actual error that was being thrown. Submitting this to improve the lives of future people like me.