### PR TITLE
Added server side AWS account ID log redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,13 +288,13 @@ as a user could potentially change this on the client side.
 
 ## API Authorization from Outside a Cluster
 
-It is possible to make requests to the Kubernetes API from a client that is outside the cluster, be that using the 
-bare Kubernetes REST API or from one of the language specific Kubernetes clients 
+It is possible to make requests to the Kubernetes API from a client that is outside the cluster, be that using the
+bare Kubernetes REST API or from one of the language specific Kubernetes clients
 (e.g., [Python](https://github.com/kubernetes-client/python)). In order to do so, you must create a bearer token that
-is included with the request to the API. This bearer token requires you append the string `k8s-aws-v1.` with a 
-base64 encoded string of a signed HTTP request to the STS GetCallerIdentity Query API. This is then sent it in the 
-`Authorization`  header of the request.  Something to note though is that the IAM Authenticator explicitly omits 
-base64 padding to avoid any `=` characters thus guaranteeing a string safe to use in URLs. Below is an example in 
+is included with the request to the API. This bearer token requires you append the string `k8s-aws-v1.` with a
+base64 encoded string of a signed HTTP request to the STS GetCallerIdentity Query API. This is then sent it in the
+`Authorization`  header of the request.  Something to note though is that the IAM Authenticator explicitly omits
+base64 padding to avoid any `=` characters thus guaranteeing a string safe to use in URLs. Below is an example in
 Python on how this token would be constructed:
 
 ```python
@@ -340,7 +340,7 @@ def get_bearer_token(cluster_id, region):
 
     # remove any base64 encoding padding:
     return 'k8s-aws-v1.' + re.sub(r'=*', '', base64_url)
-    
+
 # If making a HTTP request you would create the authorization headers as follows:
 
 headers = {'Authorization': 'Bearer ' + get_bearer_token('my_cluster', 'us-east-1')}
@@ -393,6 +393,11 @@ server:
 
   # role to assume before querying EC2 API in order to discover metadata like EC2 private DNS Name
   ec2DescribeInstancesRoleARN: arn:aws:iam::000000000000:role/DescribeInstancesRole
+
+  # AWS Account IDs to scrub from server logs. (Defaults to empty list)
+  scrubbedAccounts:
+  - "111122223333"
+  - "222233334444"
 
   # each mapRoles entry maps an IAM role to a username and set of groups
   # Each username and group can optionally contain template parameters:

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -97,6 +97,7 @@ func getConfig() (config.Config, error) {
 		BackendMode:                       viper.GetStringSlice("server.backendMode"),
 		EC2DescribeInstancesQps:           viper.GetInt("server.ec2DescribeInstancesQps"),
 		EC2DescribeInstancesBurst:         viper.GetInt("server.ec2DescribeInstancesBurst"),
+		ScrubbedAWSAccounts:               viper.GetStringSlice("server.scrubbedAccounts"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &cfg.RoleMappings); err != nil {
 		return cfg, fmt.Errorf("invalid server role mappings: %v", err)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -107,6 +107,10 @@ type Config struct {
 	// IAM ARN from these accounts automatically maps to the Kubernetes username.
 	AutoMappedAWSAccounts []string
 
+	// ScrubbedAWSAccounts is a list of AWS accounts that the role ARNs and uids
+	// are scrubbed from server log statements
+	ScrubbedAWSAccounts []string
+
 	// ServerEC2DescribeInstancesRoleARN is an optional AWS Resource Name for an IAM Role to be assumed
 	// before calling ec2:DescribeInstances to determine the private DNS of the calling kubelet (EC2 Instance).
 	// If nil, defaults to using the IAM Role attached to the instance where aws-iam-authenticator is

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -252,6 +252,36 @@ func TestAuthenticateUnableToDecodeBodyCRD(t *testing.T) {
 	validateMetrics(t, validateOpts{malformed: 1})
 }
 
+func testIsLoggableIdentity(t *testing.T) {
+	h := &handler{scrubbedAccounts: []string{"111122223333", "012345678901"}}
+
+	cases := []struct {
+		identity *token.Identity
+		want     bool
+	}{
+		{
+			&token.Identity{AccountID: "222233334444"},
+			true,
+		},
+		{
+			&token.Identity{AccountID: "111122223333"},
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		if got := h.isLoggableIdentity(c.identity); got != c.want {
+			t.Errorf(
+				"Unexpected result: isLoggableIdentity(%v): got: %t, wanted %t",
+				c.identity,
+				got,
+				c.want,
+			)
+		}
+	}
+
+}
+
 type testVerifier struct {
 	identity *token.Identity
 	err      error


### PR DESCRIPTION
This feature allows administrators to prevent specific account IDs from being emitted in server logs. 