### PR TITLE
Add AccessKeyID as variable for username

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -425,6 +425,7 @@ func (h *handler) renderTemplate(template string, identity *token.Identity) (str
 	sessionName := strings.Replace(identity.SessionName, "@", "-", -1)
 	template = strings.Replace(template, "{{SessionName}}", sessionName, -1)
 	template = strings.Replace(template, "{{SessionNameRaw}}", identity.SessionName, -1)
+	template = strings.Replace(template, "{{AccessKeyID}}", identity.AccessKeyID, -1)
 
 	return template, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -797,6 +797,13 @@ func TestRenderTemplate(t *testing.T) {
 			},
 		},
 		{
+			template: "a-{{AccessKeyID}}-b",
+			want:     "a-321-b",
+			identity: token.Identity{
+				AccessKeyID: "321",
+			},
+		},
+		{
 			template: "a-{{SessionName}}-b",
 			want:     "a-jdoe-b",
 			identity: token.Identity{


### PR DESCRIPTION
This PR allows for {{AccessKeyID}} to be used in the username field, therefore allowing cluster admins to have that information on the control plane audit logs.

Fixes: https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/263

Relates to other PRs:
[Document use of {{AccessKeyID}}](https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/332)
[Adds AccessKeyID to logs](https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/282)