### PR TITLE
(arn): validate partition against all partitions returned by the aws sdk

### DIFF
--- a/pkg/arn/arn.go
+++ b/pkg/arn/arn.go
@@ -58,12 +58,10 @@ func Canonicalize(arn string) (string, error) {
 }
 
 func checkPartition(partition string) error {
-	switch partition {
-	case endpoints.AwsPartitionID:
-	case endpoints.AwsCnPartitionID:
-	case endpoints.AwsUsGovPartitionID:
-	default:
-		return fmt.Errorf("partion %s is not recognized", partition)
+	for _, p := range endpoints.DefaultPartitions() {
+		if partition == p.ID() {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("partition %s is not recognized", partition)
 }

--- a/pkg/arn/arn_test.go
+++ b/pkg/arn/arn_test.go
@@ -17,6 +17,8 @@ var arnTests = []struct {
 	{"arn:aws:sts::123456789012:federated-user/Bob", "arn:aws:sts::123456789012:federated-user/Bob", nil},
 	{"arn:aws:iam::123456789012:root", "arn:aws:iam::123456789012:root", nil},
 	{"arn:aws:sts::123456789012:assumed-role/Org/Team/Admin/Session", "arn:aws:iam::123456789012:role/Org/Team/Admin", nil},
+	{"arn:aws-iso:iam::123456789012:user/Chris", "arn:aws-iso:iam::123456789012:user/Chris", nil},
+	{"arn:aws-iso-b:iam::123456789012:user/Chris", "arn:aws-iso-b:iam::123456789012:user/Chris", nil},
 }
 
 func TestUserARN(t *testing.T) {


### PR DESCRIPTION
Adds missing arn partitions to `checkPartition`.