### PR TITLE
Remove Chris Hein from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,14 @@
 approvers:
 - nckturner
-- christopherhein
 - micahhausler
 - wongma7
+
 reviewers:
 - mattmoyer
 - nckturner
 - mattlandis
-- christopherhein
 - micahhausler
 - justinsb
+
+emeritus_approvers:
+- christopherhein


### PR DESCRIPTION
👋 Hey friends, since I'm not very active in this project anymore I don't think it makes sense for me to be one of the approvers/reviewers thus I've moved myself to `emeritius_approvers`. 

Signed-off-by: Chris Hein <me@chrishein.com>