### PR TITLE
Support IPv6 listen address

### DIFF
--- a/pkg/config/certs.go
+++ b/pkg/config/certs.go
@@ -139,8 +139,19 @@ func (c *Config) selfSignCertificate() ([]byte, []byte, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		DNSNames:              []string{c.Hostname},
-		IPAddresses:           []net.IP{net.ParseIP(c.Address)},
+	}
+	addrIP := net.ParseIP(c.Address)
+	if !addrIP.IsUnspecified() {
+		template.IPAddresses = append(template.IPAddresses, addrIP)
+	}
+	if ip := net.ParseIP(c.Hostname); ip != nil {
+		// is an IP literal
+		if !addrIP.Equal(ip) {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		}
+	} else {
+		// is a hostname (not an IP literal)
+		template.DNSNames = append(template.DNSNames, c.Hostname)
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)

--- a/pkg/config/certs_test.go
+++ b/pkg/config/certs_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"bytes"
+	"crypto/x509"
+	"net"
+	"sort"
+	"testing"
+)
+
+func ipsEqual(a, b []net.IP) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSelfSignCert(t *testing.T) {
+	tests := []struct {
+		config   Config
+		err      error
+		dnsNames []string
+		ips      []net.IP
+	}{
+		{
+			config: Config{
+				Address:  "127.0.0.1",
+				Hostname: "127.0.0.1",
+			},
+			dnsNames: []string{},
+			ips:      []net.IP{net.IPv4(127, 0, 0, 1)},
+		},
+		{
+			config: Config{
+				Address:  "192.0.2.1",
+				Hostname: "example.com",
+			},
+			dnsNames: []string{"example.com"},
+			ips:      []net.IP{net.IPv4(192, 0, 2, 1)},
+		},
+		{
+			config: Config{
+				Address:  "::",
+				Hostname: "2001:db8::1:0",
+			},
+			dnsNames: []string{},
+			ips:      []net.IP{net.ParseIP("2001:db8::1:0")},
+		},
+	}
+
+	for _, test := range tests {
+		certBytes, keyBytes, err := test.config.selfSignCertificate()
+		if err != nil {
+			if err != test.err {
+				t.Errorf("Expected error %v, got %v", test.err, err)
+			}
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			t.Fatalf("ParseCertificate: %v", err)
+		}
+
+		key, err := x509.ParsePKCS1PrivateKey(keyBytes)
+		if err != nil {
+			t.Fatalf("ParsePKCS1PrivateKey: %v", err)
+		}
+		if err := key.Validate(); err != nil {
+			t.Errorf("private key is invalid: %v", err)
+		}
+
+		dnsNames := cert.DNSNames
+		sort.Strings(dnsNames)
+		if !stringsEqual(dnsNames, test.dnsNames) {
+			t.Errorf("expected DNSNames %v, got %v", test.dnsNames, dnsNames)
+		}
+
+		ips := cert.IPAddresses
+		sort.Slice(ips, func(i, j int) bool {
+			return bytes.Compare(ips[i].To16(), ips[j].To16()) == -1
+		})
+		if !ipsEqual(ips, test.ips) {
+			t.Errorf("expected IPs %v, got %v", test.ips, ips)
+		}
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestServerUrl(t *testing.T) {
+	tests := []struct {
+		config   Config
+		expected string
+	}{
+		{
+			config: Config{
+				Hostname: "example.com",
+				HostPort: 6443,
+			},
+			expected: "https://example.com:6443/authenticate",
+		},
+		{
+			config: Config{
+				Hostname: "127.0.0.1",
+				HostPort: 8080,
+			},
+			expected: "https://127.0.0.1:8080/authenticate",
+		},
+		{
+			config: Config{
+				Hostname: "2001:db8::1:0",
+				HostPort: 1234,
+			},
+			expected: "https://[2001:db8::1:0]:1234/authenticate",
+		},
+	}
+
+	for _, test := range tests {
+		actual := test.config.ServerURL()
+		if actual != test.expected {
+			t.Errorf("Expected %q, got %q", test.expected, actual)
+		}
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -87,7 +87,7 @@ type Config struct {
 	// HostPort is the TCP Port on which to listen for authentication checks.
 	HostPort int
 
-	// Hostname is the hostname that the server bind to.
+	// Hostname is the address clients should use for this server.
 	Hostname string
 
 	// GenerateKubeconfigPath is the output path where a generated webhook


### PR DESCRIPTION
Clarify comments to separate `Config` into:
- `Address` - the IP address the server binds to, probably 0.0.0.0
- `Hostname` - the hostname/IP that clients should use

Also fix both so they handle IPv6 literals correctly.  Fixes #339