### PR TITLE
Fix wrong image tag in example.yaml

### DIFF
--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -228,7 +228,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.2-scratch
         args:
         - server
         # uncomment if using EKS-Style ConfigMap


### PR DESCRIPTION
`602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.2` does not actually exist and causes ErrImagePull. I changed the image to one of available images in release description.