### PR TITLE
goreleaser: bump release to 0.164.0 and fix config deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,8 @@
 project_name: authenticator
 
 builds:
-  - binary: aws-iam-authenticator
+  - id: aws-iam-authenticator
+    binary: aws-iam-authenticator
     main: ./cmd/aws-iam-authenticator/
     goos:
       - darwin
@@ -16,35 +17,35 @@ builds:
       - "-s -w -X pkg.Version={{.Version}} -X pkg.CommitID={{.Commit}} -buildid=''"
 
 dockers:
-  - binaries:
+  - ids:
      - aws-iam-authenticator
     dockerfile: Dockerfile.scratch
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-scratch"
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}"
-  - binaries:
+  - ids:
      - aws-iam-authenticator
     dockerfile: Dockerfile.alpine-3.6
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-alpine-3.6"
-  - binaries:
+  - ids:
      - aws-iam-authenticator
     dockerfile: Dockerfile.alpine-3.7
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-alpine-3.7"
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-alpine"
-  - binaries:
+  - ids:
      - aws-iam-authenticator
     dockerfile: Dockerfile.debian-jessie
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-debian-jessie"
-  - binaries:
+  - ids:
      - aws-iam-authenticator
     dockerfile: Dockerfile.debian-stretch
     image_templates:
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-debian-stretch"
      - "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:{{ .Tag }}-debian"
-  - binaries:
+  - ids:
      - aws-iam-authenticator
     dockerfile: Dockerfile.amazonlinux-2
     image_templates:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 install:
-  - curl -s -L --retry 8 -o /tmp/goreleaser.tgz https://github.com/goreleaser/goreleaser/releases/download/v0.115.0/goreleaser_Linux_x86_64.tar.gz
+  - curl -s -L --retry 8 -o /tmp/goreleaser.tgz https://github.com/goreleaser/goreleaser/releases/download/v0.164.0/goreleaser_Linux_x86_64.tar.gz
   - tar -xzvf /tmp/goreleaser.tgz -C /tmp/
   - sudo mv /tmp/goreleaser /usr/local/bin
 


### PR DESCRIPTION
Required groundwork for Graviton and darwin arm64 support

Signed-off-by: Antoine Deschênes <antoine@antoinedeschenes.com>