### PR TITLE
Enrich Audit Logs with additional AWS Identity details (via audit logs' "extra" map)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -336,6 +336,9 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 
 	userExtra := map[string]authenticationv1beta1.ExtraValue{}
 	if h.isLoggableIdentity(identity) {
+		userExtra["arn"] = authenticationv1beta1.ExtraValue{identity.ARN}
+		userExtra["canonicalArn"] = authenticationv1beta1.ExtraValue{identity.CanonicalARN}
+		userExtra["sessionName"] = authenticationv1beta1.ExtraValue{identity.SessionName}
 		userExtra["accessKeyId"] = authenticationv1beta1.ExtraValue{identity.AccessKeyID}
 	}
 


### PR DESCRIPTION
## Enrich Audit Logs with additional AWS Identity details (via audit logs' "extra" map)

### Purpose

It would be helpful for consumers of Kubernetes Audit logs to be presented with all available information about the identity performing a given action against the k8s api. 

The `Identity` struct in `token.go` contains all of:

- `ARN` (string): ARN is the raw Amazon Resource Name returned by sts:GetCallerIdentity
- `CanonicalARN` (string):  CanonicalARN is the Amazon Resource Name converted to a more canonical representation. In particular, STS assumed role ARNs like "arn:aws:sts::ACCOUNTID:assumed-role/ROLENAME/SESSIONNAME" are converted to their IAM ARN equivalent "arn:aws:iam::ACCOUNTID:role/NAME"
- `AccountID` (string): AccountID is the 12 digit AWS account number.
- `UserID` (string): UserID is the unique user/role ID (e.g., "AROAAAAAAAAAAAAAAAAAA").
- `SessionName` (string): SessionName is the STS session name (or "" if this is not a session-based identity). For EC2 instance roles, this will be the EC2 instance ID (e.g., "i-0123456789abcdef0"). You should only rely on it if you trust that _only_ EC2 is allowed to assume the IAM Role. If IAM users or other roles are allowed to assume the role, they can provide (nearly) arbitrary strings here.
- `AccessKeyID` (string):  The AWS Access Key ID used to authenticate the request.  This can be used in conjuction with CloudTrail to determine the identity of the individual if the individual assumed an IAM role before making the request.

Everything in the `Identity` struct is now being logged:

- `AccessKeyID` is/was already logged in the extra map.
- `AccountID` and `UserID` is/was already logged as the `uid` in the audit log.
- `ARN`, `CanonicalARN` and `SessionName` are newly added to the extra map.

### Testing

Before this change the helper function tokenReview took only the accesskeyid string as an argument:

`tokenReview(username, uid string, groups []string, accesskeyid string) authenticationv1beta1.TokenReview`

Now, the function takes in the entire "extra" map as an arg, to verify the newly logged parts of the identity:

`tokenReview(username, uid string, groups []string, extrasMap map[string]authenticationv1beta1.ExtraValue) authenticationv1beta1.TokenReview`.

Tests were modified to check the whole map and not just one field.
