### PR TITLE
[pkg/token]: Update credential API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ users:
 - name: kubernetes-admin
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws-iam-authenticator
       args:
         - "token"
@@ -260,7 +260,7 @@ users:
 - name: aws
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws-iam-authenticator
       env:
       - name: "AWS_PROFILE"

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -38,7 +38,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientauthv1alpha1 "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
+	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"sigs.k8s.io/aws-iam-authenticator/pkg"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
 )
@@ -338,12 +338,12 @@ func (g generator) GetWithSTS(clusterID string, stsAPI stsiface.STSAPI) (Token, 
 // FormatJSON formats the json to support ExecCredential authentication
 func (g generator) FormatJSON(token Token) string {
 	expirationTimestamp := metav1.NewTime(token.Expiration)
-	execInput := &clientauthv1alpha1.ExecCredential{
+	execInput := &clientauthv1beta1.ExecCredential{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "client.authentication.k8s.io/v1alpha1",
+			APIVersion: "client.authentication.k8s.io/v1beta1",
 			Kind:       "ExecCredential",
 		},
-		Status: &clientauthv1alpha1.ExecCredentialStatus{
+		Status: &clientauthv1beta1.ExecCredentialStatus{
 			ExpirationTimestamp: &expirationTimestamp,
 			Token:               token.Token,
 		},


### PR DESCRIPTION
Kubernetes has deprecated v1alpha1, v1beta1 has been available since Kubernetes
v1.11 (kubernetes/kubernetes#64482). At the time of this commit,
community-supported versions are v1.19, v1.20, v1.21. This change will break
for Kubernetes clients using client-go or kubectl v1.10 and earlier, which
reached end-of-life community support on Feb 13, 2019. EKS ended support
for 1.10 in September of 2019.

Kubernetes 1.22 will introduce v1 of this API, but v1beta1 will likely be
supported for a period of 2 more years.

Signed-off-by: Micah Hausler <mhausler@amazon.com>