### PR TITLE
Add cloudbuild & improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/_output
 
 # OSX leaves these everywhere on SMB shares
 ._*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-08-26-1630012071
+
+FROM golang:1.16 AS builder
+WORKDIR /go/src/github.com/kubernetes-sigs/aws-iam-authenticator
+COPY . .
+RUN make bin
+RUN chown 65532 _output/bin/aws-iam-authenticator
+
+FROM $image
+COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-iam-authenticator/_output/bin/aws-iam-authenticator /aws-iam-authenticator
+ENTRYPOINT ["/aws-iam-authenticator"]

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,103 @@
-default: build
+default: bin/aws-iam-authenticator
 
-GITHUB_REPO ?= sigs.k8s.io/aws-iam-authenticator
+PKG ?= sigs.k8s.io/aws-iam-authenticator
 GORELEASER := $(shell command -v goreleaser 2> /dev/null)
 
-.PHONY: build test format codegen
+VERSION ?= v0.5.3
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+GOPROXY ?= $(shell go env GOPROXY)
+SOURCES := $(shell find . -name '*.go')
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+OUTPUT ?= _output
+CHECKSUM_FILE ?= $(OUTPUT)/bin/authenticator_$(VERSION)_checksums.txt
 
-build:
+# Architectures for binary builds
+BIN_ARCH_LINUX ?= amd64 arm64
+BIN_ARCH_WINDOWS ?= amd64
+BIN_ARCH_DARWIN ?= amd64
+
+ALL_LINUX_BIN_TARGETS = $(foreach arch,$(BIN_ARCH_LINUX),$(OUTPUT)/bin/aws-iam-authenticator_$(VERSION)_linux_$(arch))
+ALL_WINDOWS_BIN_TARGETS = $(foreach arch,$(BIN_ARCH_WINDOWS),$(OUTPUT)/bin/aws-iam-authenticator_$(VERSION)_windows_$(arch).exe)
+ALL_DARWIN_BIN_TARGETS = $(foreach arch,$(BIN_ARCH_DARWIN),$(OUTPUT)/bin/aws-iam-authenticator_$(VERSION)_darwin_$(arch))
+ALL_BIN_TARGETS = $(ALL_LINUX_BIN_TARGETS) $(ALL_WINDOWS_BIN_TARGETS) $(ALL_DARWIN_BIN_TARGETS)
+
+.PHONY: bin
+bin:
+ifeq ($(GOOS),windows)
+	$(MAKE) $(OUTPUT)/bin/aws-iam-authenticator.exe
+else
+	$(MAKE) $(OUTPUT)/bin/aws-iam-authenticator
+endif
+
+# Function checksum
+# Parameters:
+# 1: Target file on which to perform checksum
+# 2: Checksum file to append the result
+# Note: the blank line at the end of the function is required.
+define checksum
+sha256sum $(1) | sed 's|$(OUTPUT)/bin/||' >> $(2)
+
+endef
+
+.PHONY: checksums
+checksums: $(CHECKSUM_FILE)
+
+$(CHECKSUM_FILE): build-all-bins
+	rm -f $(CHECKSUM_FILE)
+	@echo $(ALL_BIN_TARGETS)
+	$(foreach target,$(ALL_BIN_TARGETS),$(call checksum,$(target),$(CHECKSUM_FILE)))
+
+$(OUTPUT)/bin/%: $(SOURCES)
+	GO111MODULE=on \
+		CGO_ENABLED=0 \
+		GOOS=$(GOOS) \
+		GOARCH=$(GOARCH) \
+		GOPROXY=$(GOPROXY) \
+		go build \
+		-o=$@ \
+		-ldflags="-w -s -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.BuildDate=$(BUILD_DATE) -X $(PKG)/pkg.CommitID=$(GIT_COMMIT)" \
+		./cmd/aws-iam-authenticator/
+
+# Function build-bin
+# Parameters:
+# 1: Target OS
+# 2: Target architecture
+# 3: Target file extension
+# Note: the blank line at the end of the function is required.
+define build-bin
+$(MAKE) $(OUTPUT)/bin/aws-iam-authenticator_$(VERSION)_$(1)_$(2)$(3) GOOS=$(1) GOARCH=$(2)
+
+endef
+
+.PHONY: build-all-bins
+build-all-bins:
+	$(foreach arch,$(BIN_ARCH_LINUX),$(call build-bin,linux,$(arch),))
+	$(foreach arch,$(BIN_ARCH_WINDOWS),$(call build-bin,windows,$(arch),.exe))
+	$(foreach arch,$(BIN_ARCH_DARWIN),$(call build-bin,darwin,$(arch),))
+
+.PHONY: goreleaser
+goreleaser:
 ifndef GORELEASER
 	$(error "goreleaser not found (`go get -u -v github.com/goreleaser/goreleaser` to fix)")
 endif
 	$(GORELEASER) --skip-publish --rm-dist --snapshot
 
+.PHONY: test
 test:
-	go test -v -coverprofile=coverage.out -race $(GITHUB_REPO)/...
+	go test -v -coverprofile=coverage.out -race $(PKG)/...
 	go tool cover -html=coverage.out -o coverage.html
 
+.PHONY: format
 format:
 	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \
 	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"
 
+.PHONY: codegen
 codegen:
 	./hack/update-codegen.sh
+
+.PHONY: clean
+clean:
+	rm -rf $(shell pwd)/_output

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,17 @@
+images:
+  - 'gcr.io/$PROJECT_ID/aws-iam-authenticator:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/aws-iam-authenticator:latest'
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/aws-iam-authenticator:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/aws-iam-authenticator:latest
+    - --build-arg=IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-08-26-1630012071
+    - .
+substitutions:
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'master'
+timeout: 1200s

--- a/cmd/aws-iam-authenticator/version.go
+++ b/cmd/aws-iam-authenticator/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	goVersion "go.hein.dev/go-version"
+	goversion "go.hein.dev/go-version"
 	"sigs.k8s.io/aws-iam-authenticator/pkg"
 )
 
@@ -17,7 +17,7 @@ var (
 		Short: "Version will output the current build information",
 		Long:  ``,
 		Run: func(_ *cobra.Command, _ []string) {
-			resp := goVersion.FuncWithOutput(shortened, pkg.Version, pkg.CommitID, date, output)
+			resp := goversion.FuncWithOutput(shortened, pkg.Version, pkg.CommitID, pkg.BuildDate, output)
 			fmt.Print(resp)
 			return
 		},

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -17,8 +17,11 @@ limitations under the License.
 package pkg
 
 var (
-	// Semantic version of the build. Set at build time
+	// Set at build time
+	// Semantic version of the build.
 	Version = "unversioned"
-	// Commit id of the build. Set at build time
+	// Commit id of the build.
 	CommitID = ""
+	// Build Date of the build.
+	BuildDate = ""
 )


### PR DESCRIPTION
* Add cloudbuild.yaml.
* Add Dockerfile with minimal image for base which will be built
  on merge and pushed to
  gcr.io/k8s-staging-provider-aws/aws-iam-authenticator.
* Add a new target for building binaries and creating a checksum file
  for them to start getting away from the need for the goreleaser
  dependency.
* Add build date to version command.
