### PR TITLE
Run integration tests with per-test role

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -14,29 +14,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function role_arn() {
-    sts=$(aws sts get-caller-identity --query "Arn" --output text)
-    tmp=${sts#*/}
+set -o errexit
+set -o pipefail
+set -o nounset
+
+command -v aws || { echo "Command 'aws' not found" && exit 1; }
+
+function account_from_default_credentials() {
+    sts_account=$(aws sts get-caller-identity --query "Account" --output text)
+    echo $sts_account
+}
+
+function role_arn_from_default_credentials() {
+    sts_arn=$(aws sts get-caller-identity --query "Arn" --output text)
+    tmp=${sts_arn#*/}
     role_name=${tmp%/*}
-    tmp=${sts%:*}
+    tmp=${sts_arn%:*}
     account_id=${tmp##*:}
     echo "arn:aws:iam::${account_id}:role/${role_name}"
 }
 
+function write-role-policy() {
+    local account_id=$1
+    local file_name=$2
+
+    cat > ${file_name} <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+CREATE_TEST_ROLE="${CREATE_TEST_ROLE:-true}"
+GENERATED_TEST_ROLE_NAME="aws-iam-authenticator-test-role-${RANDOM}"
+GENERATED_TEST_ROLE_POLICY_FILE=/tmp/role-policy.json
 KUBERNETES_TAG="v1.22.1"
 REPO_ROOT="$(cd "$( dirname "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd)"
 TEST_ARTIFACTS="${TEST_ARTIFACTS:-"${REPO_ROOT}/test-artifacts"}"
-TEST_ROLE_ARN="${TEST_ROLE_ARN:-$(role_arn)}"
+TEST_ROLE_ARN="${TEST_ROLE_ARN:-$(role_arn_from_default_credentials)}"
 
-command -v aws || { echo "Command 'aws' not found" && exit 1; }
+function cleanup {
+    if [[ "${CREATE_TEST_ROLE}" = "true" ]]; then
+        echo "Cleaning up test role ${GENERATED_TEST_ROLE_NAME}"
+        aws iam delete-role --role-name "${GENERATED_TEST_ROLE_NAME}" || echo "Failed to clean up test role ${GENERATED_TEST_ROLE_NAME}"
+    fi
+}
+trap cleanup EXIT
+
+if [[ "${CREATE_TEST_ROLE}" = "true" ]]; then
+    echo "Creating test role ${GENERATED_TEST_ROLE_NAME}"
+    write-role-policy "$(account_from_default_credentials)" ${GENERATED_TEST_ROLE_POLICY_FILE}
+    create_role_output=$(aws iam create-role --role-name "${GENERATED_TEST_ROLE_NAME}" --assume-role-policy-document "file://${GENERATED_TEST_ROLE_POLICY_FILE}")
+    rm ${GENERATED_TEST_ROLE_POLICY_FILE}
+    TEST_ROLE_ARN="$(echo ${create_role_output} | jq -r '.Role.Arn')"
+fi
 
 make clean
 make bin
 
-if [[ ! -d ${TEST_ARTIFACTS}/k8s.io/kubernetes ]]; then
-    mkdir -p ${TEST_ARTIFACTS}/k8s.io/kubernetes
-    git clone --branch ${KUBERNETES_TAG} --depth 1 https://github.com/kubernetes/kubernetes.git ${TEST_ARTIFACTS}/k8s.io/kubernetes --depth 1
+if [[ -d ${TEST_ARTIFACTS}/k8s.io/kubernetes ]]; then
+    rm -rf ${TEST_ARTIFACTS}/k8s.io/kubernetes
 fi
+
+mkdir -p ${TEST_ARTIFACTS}/k8s.io/kubernetes
+git clone --branch ${KUBERNETES_TAG} --depth 1 https://github.com/kubernetes/kubernetes.git ${TEST_ARTIFACTS}/k8s.io/kubernetes --depth 1
+
 pushd ${TEST_ARTIFACTS}/k8s.io/kubernetes
 make generated_files
 popd

--- a/tests/integration/server/server_test.go
+++ b/tests/integration/server/server_test.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/tests/integration/testutils"
@@ -20,16 +21,37 @@ func TestServer(t *testing.T) {
 			ModifyAuthenticatorServerConfig: func(*config.Config) {},
 			AuthenticatorClientBinaryPath:   authenticatorBinaryPath,
 			TestArtifacts:                   testArtifactsDir,
+			ClusterID:                       "test-cluster",
+			BackendMode:                     []string{"EKSConfigMap"},
+			RoleArn:                         roleARN,
 		},
 	)
 
 	t.Log("Creating aws-auth")
-	_, err := adminClient.CoreV1().ConfigMaps("kube-system").Create(context.TODO(), &v1.ConfigMap{
+	userName := "test-user"
+	_, err := adminClient.CoreV1().ConfigMaps("kube-system").Create(context.TODO(), &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "aws-auth"},
-		Data:       map[string]string{"mapRoles": fmt.Sprintf("    - rolearn: %s\n      username: system:node:{{EC2PrivateDNSName}}\n      groups:\n        - system:bootstrappers\n        - system:nodes", roleARN)},
+		Data:       map[string]string{"mapRoles": fmt.Sprintf("    - rolearn: %s\n      username: %s\n", roleARN, userName)},
 	}, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error creating aws-auth configmap: %v\n", err)
+	}
+
+	_, err = adminClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-user-binding"},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: userName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "cluster-admin",
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating clusterrolebinding: %v\n", err)
 	}
 
 	t.Log("Testing authentication")


### PR DESCRIPTION
* Create IAM role for each test run in test-integration.sh.
* Use role in integration test.
* This is necessary in order to run integration tests in prow
  because the default AWS credentials are an IAM user, and this
  avoids relying on any assumptions about the default credentials.