### PR TITLE
Use ./hack/install-etcd.sh

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -90,8 +90,11 @@ git clone --branch ${KUBERNETES_TAG} --depth 1 https://github.com/kubernetes/kub
 
 pushd ${TEST_ARTIFACTS}/k8s.io/kubernetes
 make generated_files
+./hack/install-etcd.sh
+export PATH="${TEST_ARTIFACTS}/k8s.io/kubernetes/third_party/etcd:${PATH}"
 popd
 
 pushd ${REPO_ROOT}/tests/integration
+export AWS_REGION=${AWS_REGION:-us-west-2}
 go test -v ./server -test-artifacts-dir="${TEST_ARTIFACTS}" -authenticator-binary-path="${REPO_ROOT}/_output/bin/aws-iam-authenticator" -role-arn="${TEST_ROLE_ARN}"
 popd


### PR DESCRIPTION
Integration tests fail due to inability to find etcd:

```

Cannot find etcd, cannot run integration tests
Please see https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md#install-etcd-dependency for instructions.

You can use 'hack/install-etcd.sh' to install a copy in third_party/.

F1011 22:22:28.628086   35042 etcd.go:173] cannot run integration tests: unable to start etcd: could not find etcd in PATH: exec: "etcd": executable file not found in $PATH
goroutine 1 [running]:
k8s.io/klog/v2.stacks(0x1)
	/home/prow/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:1026 +0x8a
k8s.io/klog/v2.(*loggingT).output(0x72d3140, 0x3, {0x0, 0x0}, 0xc00004e460, 0x0, {0x5adfbe5, 0xc0000380d0}, 0x0, 0x0)
	/home/prow/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:975 +0x63d
k8s.io/klog/v2.(*loggingT).printf(0x12, 0x46719e5, {0x0, 0x0}, {0x0, 0x0}, {0x46bf398, 0x36}, {0xc0000380d0, 0x1, ...})
	/home/prow/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:753 +0x1e5
k8s.io/klog/v2.Fatalf(...)
	/home/prow/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:1514
k8s.io/kubernetes/test/integration/framework.EtcdMain(0xc000cbfec0)
	/home/prow/go/src/github.com/kubernetes-sigs/aws-iam-authenticator/test-artifacts/k8s.io/kubernetes/test/integration/framework/etcd.go:173 +0xcb
sigs.k8s.io/aws-iam-authenticator/tests/integration/server.TestMain(0xc000a24900)
	/home/prow/go/src/github.com/kubernetes-sigs/aws-iam-authenticator/tests/integration/server/main_test.go:37 +0x176
main.main()
	_testmain.go:45 +0x165
```

Attempting to use ./hack/install-etcd.sh to install it. 