### PR TITLE
Add jaypipes to approvers/reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,14 @@ approvers:
 - nckturner
 - micahhausler
 - wongma7
+- jaypipes
 
 reviewers:
 - nckturner
 - micahhausler
 - justinsb
 - wongma7
+- jaypipes
 
 emeritus_approvers:
 - christopherhein


### PR DESCRIPTION
I'd like to add Jay to the OWNERS file as an approver and reviewer so that he can take a more active role in PR reviews, as we are short staffed on this project.  He needs to be added as a member of kubernetes-sigs first. 