### PR TITLE
Fix panic when cache file can't be Stat-ed

### DIFF
--- a/pkg/token/filecache_test.go
+++ b/pkg/token/filecache_test.go
@@ -59,7 +59,11 @@ type testFS struct {
 
 func (t *testFS) Stat(filename string) (os.FileInfo, error) {
 	t.filename = filename
-	return &t.fileinfo, t.err
+	if t.err == nil {
+		return &t.fileinfo, nil
+	} else {
+		return nil, t.err
+	}
 }
 
 func (t *testFS) ReadFile(filename string) ([]byte, error) {


### PR DESCRIPTION
The code currently assumes that Stat always return a `FileInfo` object,
but if the file can't be `Stat`-ed (e.g. due to a permissions error), `Stat`
can return a nil `FileInfo`, plus an error. The error is only handled if
it's a "not exists" error, but there are other errors that can be
returned too.

This wasn't caught by the tests, since the mocked out `Stat` always
returns a `FileInfo`, even when an error is returned.

This commit also changes from `os.IsNotExist(err)` to `errors.Is(err, fs.ErrNotExist)` as recommended by [the documentation for `os.IsNotExist`](https://pkg.go.dev/os#IsNotExist).

Fixes #349.