### PR TITLE
Fix missing status definition in v1 CRD

### DIFF
--- a/deploy/iamidentitymapping.yaml
+++ b/deploy/iamidentitymapping.yaml
@@ -34,5 +34,12 @@ spec:
                   type: array
                   items:
                     type: string
+            status:
+              type: object
+              properties:
+                canonicalARN:
+                  type: string
+                userID:
+                  type: string
       subresources:
         status: {}


### PR DESCRIPTION
As suggested by https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/406#issuecomment-947592660

This fixes the v1 CRD, otherwise aws-iam-authenticator would reporting syncing the CRD but all auth requests were rejected.