### PR TITLE
Use full package name for goreleaser version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - "-s -w -X pkg.Version={{.Version}} -X pkg.CommitID={{.Commit}} -buildid=''"
+      - "-s -w -X sigs.k8s.io/aws-iam-authenticator/pkg.Version={{.Version}} -X sigs.k8s.io/aws-iam-authenticator/pkg.CommitID={{.Commit}} -buildid=''"
 
 dockers:
   - use: buildx


### PR DESCRIPTION
Tested with:

```
$ goreleaser release --snapshot
...
```
and
```
$ ./dist/aws-iam-authenticator_linux_amd64/aws-iam-authenticator version
{"Version":"git-39916f8b","Commit":"39916f8b5757194364ae3509c417572f17f9df18"}
```

Fixes #412