### PR TITLE
Remove duplicate InitMetrics

### DIFF
--- a/cmd/aws-iam-authenticator/verify.go
+++ b/cmd/aws-iam-authenticator/verify.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"os"
 
-	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/aws-iam-authenticator/verify.go
+++ b/cmd/aws-iam-authenticator/verify.go
@@ -72,7 +72,6 @@ var verifyCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(verifyCmd)
-	metrics.InitMetrics(prometheus.DefaultRegisterer)
 	verifyCmd.Flags().StringP("token", "t", "", "Token to verify")
 	verifyCmd.Flags().StringP("output", "o", "", "Output format. Only `json` is supported currently.")
 	viper.BindPFlag("token", verifyCmd.Flags().Lookup("token"))


### PR DESCRIPTION
Encountered an error when trying to launch server. 

```
panic: duplicate metrics collector registration attempted
```

`InitMetrics(...)` is called twice, so removing the duplicate call.