### PR TITLE
Bump version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: bin/aws-iam-authenticator
 PKG ?= sigs.k8s.io/aws-iam-authenticator
 GORELEASER := $(shell command -v goreleaser 2> /dev/null)
 
-VERSION ?= v0.5.6
+VERSION ?= v0.5.9
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= $(shell go env GOPROXY)


### PR DESCRIPTION
This wasn't done in previous releases, so bumping to the next version that doesn't have a tag:  v0.5.9