### PR TITLE
solve the problem that client-go cannot find v1alpha1 after upgrading to 0.24

### DIFF
--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -19,7 +19,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/apis/clientauthentication"
 	clientauthv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
-	clientauthv1alpha1 "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
 	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 )
@@ -347,11 +346,6 @@ func TestFormatJson(t *testing.T) {
 			Name:             "KUBERNETES_EXEC_INFO with v1beta1",
 			EnvKey:           "KUBERNETES_EXEC_INFO",
 			ExpectApiVersion: clientauthv1beta1.SchemeGroupVersion.String(),
-		},
-		{
-			Name:             "KUBERNETES_EXEC_INFO with v1alpha1",
-			EnvKey:           "KUBERNETES_EXEC_INFO",
-			ExpectApiVersion: clientauthv1alpha1.SchemeGroupVersion.String(),
 		},
 		{
 			Name:             "KUBERNETES_EXEC_INFO with v1",


### PR DESCRIPTION
reference link https://github.com/fengshunli/aws-iam-authenticator/tree/main