### PR TITLE
Add new backend mode DYNAMICFILE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
     github.com/aws/aws-sdk-go v1.44.107
+    github.com/fsnotify/fsnotify v1.4.9
     github.com/gofrs/flock v0.7.0
     github.com/manifoldco/promptui v0.9.0
     github.com/onsi/ginkgo v1.14.0

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -32,8 +32,8 @@ type IdentityMapping struct {
 // list of Kubernetes groups. The username and groups are specified as templates
 // that may optionally contain two template parameters:
 //
-//  1) "{{AccountID}}" is the 12 digit AWS ID.
-//  2) "{{SessionName}}" is the role session name.
+//  1. "{{AccountID}}" is the 12 digit AWS ID.
+//  2. "{{SessionName}}" is the role session name.
 //
 // The meaning of SessionName depends on the type of entity assuming the role.
 // In the case of an EC2 instance role this will be the EC2 instance ID. In the
@@ -169,4 +169,6 @@ type Config struct {
 	// understand we don't need to change
 	EC2DescribeInstancesQps   int
 	EC2DescribeInstancesBurst int
+	//Dynamic File Path for DynamicFile BackendMode
+	DynamicFilePath string
 }

--- a/pkg/mapper/dynamicfile/dynamicfile.go
+++ b/pkg/mapper/dynamicfile/dynamicfile.go
@@ -1,0 +1,244 @@
+package dynamicfile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+)
+
+type DynamicFileMapStore struct {
+	mutex sync.RWMutex
+	users map[string]config.UserMapping
+	roles map[string]config.RoleMapping
+	// Used as set.
+	awsAccounts map[string]interface{}
+	filename    string
+}
+
+type DynamicFileData struct {
+	// RoleMappings is a list of mappings from AWS IAM Role to
+	// Kubernetes username + groups.
+	RoleMappings []config.RoleMapping `json:"mapRoles"`
+
+	// UserMappings is a list of mappings from AWS IAM User to
+	// Kubernetes username + groups.
+	UserMappings []config.UserMapping `json:"mapUsers"`
+	// AutoMappedAWSAccounts is a list of AWS accounts that are allowed without an explicit user/role mapping.
+	// IAM ARN from these accounts automatically maps to the Kubernetes username.
+	AutoMappedAWSAccounts []string `json:"mapAccounts"`
+}
+
+type ErrParsingMap struct {
+	errors []error
+}
+
+func (err ErrParsingMap) Error() string {
+	return fmt.Sprintf("error parsing dynamic file: %v", err.errors)
+}
+
+func waitUntilFileAvailable(filename string) error {
+	for {
+		_, err := os.Stat(filename)
+		if os.IsNotExist(err) {
+			time.Sleep(1 * time.Second)
+			continue
+		} else {
+			return err
+		}
+	}
+}
+
+func (m *DynamicFileMapStore) loadDynamicFile() error {
+	err := waitUntilFileAvailable(m.filename)
+	if err != nil {
+		logrus.Errorf("LoadDynamicFile: failed to wait till dynamic file available %v", err)
+		return err
+	}
+	logrus.Infof("LoadDynamicFile: %v is available. loading", m.filename)
+	// load the initial file content into memory
+	userMappings, roleMappings, awsAccounts, err := ParseMap(m.filename)
+	if err != nil {
+		logrus.Errorf("LoadDynamicFile: There was an error parsing the dynamic file: %+v. Map is not updated. Please correct dynamic file", err)
+		return err
+	} else {
+		m.saveMap(userMappings, roleMappings, awsAccounts)
+	}
+	return nil
+}
+
+func NewDynamicFileMapStore(filename string) (*DynamicFileMapStore, error) {
+	ms := DynamicFileMapStore{}
+	ms.filename = filename
+	return &ms, nil
+}
+
+func (m *DynamicFileMapStore) startLoadDynamicFile(stopCh <-chan struct{}) {
+	go wait.Until(func() {
+		m.loadDynamicFile()
+		// start to watch the file change
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			logrus.Errorf("startLoadDynamicFile: failed when call fsnotify.NewWatcher, %+v", err)
+		}
+		err = watcher.Add(m.filename)
+		if err != nil {
+			logrus.Errorf("startLoadDynamicFile: could not add file to watcher %v", err)
+		}
+
+		defer watcher.Close()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case event := <-watcher.Events:
+				switch {
+				case event.Op&fsnotify.Write == fsnotify.Write, event.Op&fsnotify.Create == fsnotify.Create:
+					// reload the access entry file
+					logrus.Info("startLoadDynamicFile: got WRITE/CREATE event reload it the memory")
+					m.loadDynamicFile()
+				case event.Op&fsnotify.Rename == fsnotify.Rename, event.Op&fsnotify.Remove == fsnotify.Remove:
+					logrus.Info("startLoadDynamicFile: got RENAME/REMOVE event")
+					// test if the "REMOVE" is triggered by vi or cp cmd
+					_, err := os.Stat(m.filename)
+					if os.IsNotExist(err) {
+						// the "REMOVE" event is  not triggered by vi or cp cmd
+						// reset memory
+						userMappings := make([]config.UserMapping, 0)
+						roleMappings := make([]config.RoleMapping, 0)
+						awsAccounts := make([]string, 0)
+						m.saveMap(userMappings, roleMappings, awsAccounts)
+					}
+					return
+				}
+			case err := <-watcher.Errors:
+				logrus.Errorf("startLoadDynamicFile: watcher.Errors for dynamic file %v", err)
+			}
+		}
+	}, time.Second, stopCh)
+}
+
+func ParseMap(filename string) (userMappings []config.UserMapping, roleMappings []config.RoleMapping, awsAccounts []string, err error) {
+	errs := make([]error, 0)
+	userMappings = make([]config.UserMapping, 0)
+	roleMappings = make([]config.RoleMapping, 0)
+
+	dynamicContent, err := os.ReadFile(filename)
+	if err != nil {
+		logrus.Errorf("ParseMap: could not read from dynamic file")
+		return userMappings, roleMappings, awsAccounts, err
+	}
+
+	var dynamicFileData DynamicFileData
+	err = json.Unmarshal([]byte(dynamicContent), &dynamicFileData)
+	if err != nil {
+		if len(dynamicContent) == 0 {
+			return userMappings, roleMappings, awsAccounts, nil
+		}
+		logrus.Error("ParseMap: could not unmarshal dynamic file.")
+		return userMappings, roleMappings, awsAccounts, err
+	}
+
+	for _, userMapping := range dynamicFileData.UserMappings {
+		err = userMapping.Validate()
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			userMappings = append(userMappings, userMapping)
+		}
+	}
+
+	for _, roleMapping := range dynamicFileData.RoleMappings {
+		err = roleMapping.Validate()
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			roleMappings = append(roleMappings, roleMapping)
+		}
+	}
+
+	awsAccounts = dynamicFileData.AutoMappedAWSAccounts[:]
+
+	if len(errs) > 0 {
+		logrus.Warnf("ParseMap: Errors parsing dynamic file: %+v", errs)
+		err = ErrParsingMap{errors: errs}
+	}
+	return userMappings, roleMappings, awsAccounts, err
+}
+func (ms *DynamicFileMapStore) saveMap(
+	userMappings []config.UserMapping,
+	roleMappings []config.RoleMapping,
+	awsAccounts []string) {
+
+	ms.mutex.Lock()
+	defer ms.mutex.Unlock()
+	ms.users = make(map[string]config.UserMapping)
+	ms.roles = make(map[string]config.RoleMapping)
+	ms.awsAccounts = make(map[string]interface{})
+
+	for _, user := range userMappings {
+		ms.users[user.Key()] = user
+	}
+	for _, role := range roleMappings {
+		ms.roles[role.Key()] = role
+	}
+	for _, awsAccount := range awsAccounts {
+		ms.awsAccounts[awsAccount] = nil
+	}
+}
+
+// UserNotFound is the error returned when the user is not found in the config map.
+var UserNotFound = errors.New("User not found in dynamic file")
+
+// RoleNotFound is the error returned when the role is not found in the config map.
+var RoleNotFound = errors.New("Role not found in dynamic file")
+
+func (ms *DynamicFileMapStore) UserMapping(arn string) (config.UserMapping, error) {
+	ms.mutex.RLock()
+	defer ms.mutex.RUnlock()
+	for _, user := range ms.users {
+		if user.Matches(arn) {
+			return user, nil
+		}
+	}
+	return config.UserMapping{}, UserNotFound
+}
+
+func (ms *DynamicFileMapStore) RoleMapping(arn string) (config.RoleMapping, error) {
+	ms.mutex.RLock()
+	defer ms.mutex.RUnlock()
+	for _, role := range ms.roles {
+		if role.Matches(arn) {
+			return role, nil
+		}
+	}
+	return config.RoleMapping{}, RoleNotFound
+}
+
+func (ms *DynamicFileMapStore) AWSAccount(id string) bool {
+	ms.mutex.RLock()
+	defer ms.mutex.RUnlock()
+	_, ok := ms.awsAccounts[id]
+	return ok
+}
+
+func (ms *DynamicFileMapStore) LogMapping() {
+	ms.mutex.RLock()
+	defer ms.mutex.RUnlock()
+	for _, user := range ms.users {
+		logrus.Info(user)
+	}
+	for _, role := range ms.roles {
+		logrus.Info(role)
+	}
+	for awsAccount, _ := range ms.awsAccounts {
+		logrus.Info(awsAccount)
+	}
+}

--- a/pkg/mapper/dynamicfile/dynamicfile_test.go
+++ b/pkg/mapper/dynamicfile/dynamicfile_test.go
@@ -1,0 +1,325 @@
+package dynamicfile
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+)
+
+var (
+	testUser = config.UserMapping{UserARN: "arn:aws:iam::012345678912:user/matt", Username: "matlan", Groups: []string{"system:master", "dev"}}
+	testRole = config.RoleMapping{RoleARN: "arn:aws:iam::012345678912:role/computer", Username: "computer", Groups: []string{"system:nodes"}}
+)
+
+func makeStore() DynamicFileMapStore {
+	ms := DynamicFileMapStore{
+		users:       make(map[string]config.UserMapping),
+		roles:       make(map[string]config.RoleMapping),
+		awsAccounts: make(map[string]interface{}),
+		filename:    "test.txt",
+	}
+	ms.users["arn:aws:iam::012345678912:user/matt"] = testUser
+	ms.roles["arn:aws:iam::012345678912:role/comp*"] = testRole
+	ms.awsAccounts["123"] = nil
+	return ms
+}
+
+func TestUserMapping(t *testing.T) {
+	ms := makeStore()
+	user, err := ms.UserMapping("arn:aws:iam::012345678912:user/matt")
+	if err != nil {
+		t.Errorf("Could not find user 'matt' in map")
+	}
+	if !reflect.DeepEqual(user, testUser) {
+		t.Errorf("User for 'matt' does not match expected values. (Actual: %+v, Expected: %+v", user, testUser)
+	}
+
+	user, err = ms.UserMapping("nic")
+	if err != UserNotFound {
+		t.Errorf("UserNotFound error was not returned for user 'nic'")
+	}
+	if !reflect.DeepEqual(user, config.UserMapping{}) {
+		t.Errorf("User value returned when user is not in the map was not empty: %+v", user)
+	}
+}
+
+func TestRoleMapping(t *testing.T) {
+	ms := makeStore()
+	role, err := ms.RoleMapping("arn:aws:iam::012345678912:role/computer")
+	if err != nil {
+		t.Errorf("Could not find user 'instance in map")
+	}
+	if !reflect.DeepEqual(role, testRole) {
+		t.Errorf("Role for 'instance' does not match expected value. (Acutal: %+v, Expected: %+v", role, testRole)
+	}
+
+	role, err = ms.RoleMapping("borg")
+	if err != RoleNotFound {
+		t.Errorf("RoleNotFound error was not returend for role 'borg'")
+	}
+	if !reflect.DeepEqual(role, config.RoleMapping{}) {
+		t.Errorf("Role value returend when role is not in map was not empty: %+v", role)
+	}
+}
+
+func TestAWSAccount(t *testing.T) {
+	ms := makeStore()
+	if !ms.AWSAccount("123") {
+		t.Errorf("Expected aws account '123' to be in accounts list: %v", ms.awsAccounts)
+	}
+	if ms.AWSAccount("345") {
+		t.Errorf("Did not expect account '345' to be in accounts list: %v", ms.awsAccounts)
+	}
+}
+
+var origFileContent = `
+{
+  "mapRoles": [
+    {
+      "rolearn": "arn:aws:iam::000000000098:role/KubernetesAdmin",
+      "username": "kubernetes-admin",
+      "groups": [
+        "system:masters"
+      ]
+    }
+  ],
+  "mapUsers": [
+    {
+      "userarn": "arn:aws:iam::000000000000:user/Alice",
+      "username": "alice",
+      "groups": [
+        "system:masters"
+      ]
+    },
+    {
+      "userarn": "arn:aws:iam::000000000002:user/Alice2",
+      "username": "alice2",
+      "groups": [
+        "system:masters"
+      ]
+    }
+  ],
+  "mapAccounts": [
+    "012345678901",
+    "456789012345"
+  ]
+}
+`
+
+var updatedFileContent = `
+{
+  "mapRoles": [
+    {
+      "rolearn": "arn:aws:iam::000000000098:role/KubernetesAdmin",
+      "username": "kubernetes-admin",
+      "groups": [
+        "system:masters"
+      ]
+    },
+    {
+      "rolearn": "arn:aws:iam::000000000002:role/KubernetesNode",
+      "username": "aws:{{AccountID}}:instance:{{SessionName}}",
+      "groups": [
+        "system:bootstrappers",
+        "aws:instances"
+      ]
+    },
+    {
+      "rolearn": "arn:aws:iam::000000000003:role/KubernetesNode",
+      "username": "system:node:{{EC2PrivateDNSName}}",
+      "groups": [
+        "system:nodes",
+        "system:bootstrappers"
+      ]
+    },
+    {
+      "rolearn": "arn:aws:iam::000000000004:role/KubernetesAdmin",
+      "username": "admin:{{SessionName}}",
+      "groups": [
+        "system:masters"
+      ]
+    }
+  ],
+  "mapUsers": [
+    {
+      "userarn": "arn:aws:iam::000000000000:user/Alice",
+      "username": "alice",
+      "groups": [
+        "system:masters"
+      ]
+    }
+  ],
+  "mapAccounts": [
+    "012345678901",
+    "456789012345"
+  ]
+}
+`
+
+func TestLoadDynamicFile(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	//When the file doesn't exist, expect mapping should be empty map
+	ms, err := NewDynamicFileMapStore("/tmp/test.txt")
+	if err != nil {
+		t.Errorf("failed to create a DynamicFileMapper")
+	}
+
+	ms.startLoadDynamicFile(stopCh)
+	time.Sleep(1 * time.Second)
+	ms.mutex.RLock()
+	if len(ms.roles) != 0 {
+		t.Fatalf("testing failed as mapping should be empty since dynamic file doesn't exist")
+	}
+	if len(ms.users) != 0 {
+		t.Fatalf("testing failed as mapping should be empty since dynamic file doesn't exist")
+	}
+	if len(ms.awsAccounts) != 0 {
+		t.Fatalf("testing failed as mapping should be empty since dynamic file doesn't exist")
+	}
+	ms.mutex.RUnlock()
+
+	//user create the dynamic file, expect that mapping should contain item
+	time.Sleep(1 * time.Second)
+	data := []byte(origFileContent)
+	err = os.WriteFile("/tmp/test.txt", data, 0600)
+	if err != nil {
+		t.Errorf("failed to create a local file /tmp/test.txt")
+	}
+
+	time.Sleep(2 * time.Second)
+	ms.mutex.RLock()
+	if len(ms.roles) == 0 {
+		t.Fatalf("testing failed as mapping should contain item since dynamic file has content")
+	}
+	if len(ms.users) == 0 {
+		t.Fatalf("testing failed as mapping should contain item since dynamic file has content")
+	}
+	if len(ms.awsAccounts) == 0 {
+		t.Fatalf("testing failed as mapping should contain item since dynamic file has content")
+	}
+	ms.mutex.RUnlock()
+	//user update the dynamic file,expect mapping should be equal to expectedMapStore
+	expectedData := []byte(updatedFileContent)
+	err = os.WriteFile("/tmp/expected.txt", expectedData, 0600)
+
+	expectedMapStore, err := NewDynamicFileMapStore("/tmp/expected.txt")
+	if err != nil {
+		t.Errorf("failed to create expected DynamicFileMapper")
+	}
+	expectedUserMappings, expectedRoleMappings, expectedAwsAccounts, err := ParseMap(expectedMapStore.filename)
+	if err != nil {
+		t.Errorf("failed to ParseMap expected DynamicFileMapper")
+	}
+	expectedMapStore.saveMap(expectedUserMappings, expectedRoleMappings, expectedAwsAccounts)
+
+	time.Sleep(1 * time.Second)
+
+	//modify the dynamic file
+	data = []byte(updatedFileContent)
+	err = os.WriteFile("/tmp/test.txt", data, 0600)
+	if err != nil {
+		t.Errorf("failed to modify a local file /tmp/test.txt")
+	}
+	time.Sleep(1 * time.Second)
+	ms.mutex.RLock()
+	if !reflect.DeepEqual(expectedMapStore.roles, ms.roles) {
+		t.Fatalf("testing failed as mapping doesn't update after file modification")
+	}
+	if !reflect.DeepEqual(expectedMapStore.users, ms.users) {
+		t.Fatalf("testing failed as mapping doesn't update after file modification")
+	}
+	if !reflect.DeepEqual(expectedMapStore.awsAccounts, ms.awsAccounts) {
+		t.Fatalf("testing failed as mapping doesn't update after file modification")
+	}
+	ms.mutex.RUnlock()
+	//user delete the dynamic file, expect mapping should be empty
+	err = os.Remove("/tmp/test.txt")
+	if err != nil {
+		t.Errorf("failed to delete a local file /tmp/test.txt")
+	}
+	time.Sleep(1 * time.Second)
+	ms.mutex.RLock()
+	if len(ms.roles) != 0 {
+		t.Fatalf("testing failed as mapping doesn't update after file deletion")
+	}
+	if len(ms.users) != 0 {
+		t.Fatalf("testing failed as mapping doesn't update after file deletion")
+	}
+	if len(ms.awsAccounts) != 0 {
+		t.Fatalf("testing failed as mapping doesn't update after file deletion")
+	}
+	ms.mutex.RUnlock()
+	//user add file back, expect mapping should be equal to expectedMap
+	time.Sleep(1 * time.Second)
+	data = []byte(updatedFileContent)
+	err = os.WriteFile("/tmp/test.txt", data, 0600)
+	if err != nil {
+		t.Errorf("failed to create a local file /tmp/test.txt")
+	}
+
+	time.Sleep(2 * time.Second)
+	ms.mutex.RLock()
+	if !reflect.DeepEqual(expectedMapStore.roles, ms.roles) {
+		t.Fatalf("testing failed as mapping doesn't update after file modification")
+	}
+	if !reflect.DeepEqual(expectedMapStore.users, ms.users) {
+		t.Fatalf("testing failed as mapping doesn't update after file modification")
+	}
+	if !reflect.DeepEqual(expectedMapStore.awsAccounts, ms.awsAccounts) {
+		t.Fatalf("testing failed as mapping doesn't update after file modification")
+	}
+	ms.mutex.RUnlock()
+	//clean test files
+	defer os.Remove("/tmp/test.txt")
+	defer os.Remove("/tmp/expected.txt")
+
+}
+
+func TestParseMap(t *testing.T) {
+
+	data := []byte(origFileContent)
+	err := os.WriteFile("/tmp/test.txt", data, 0600)
+	if err != nil {
+		t.Errorf("failed to create a local file /tmp/test.txt")
+	}
+	ms, err := NewDynamicFileMapStore("/tmp/test.txt")
+	if err != nil {
+		t.Errorf("failed to create a DynamicFileMapper")
+	}
+
+	u, r, a, err := ParseMap(ms.filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origUserMappings := []config.UserMapping{
+		{UserARN: "arn:aws:iam::000000000000:user/Alice", Username: "alice", Groups: []string{"system:masters"}},
+		{UserARN: "arn:aws:iam::000000000002:user/Alice2", Username: "alice2", Groups: []string{"system:masters"}},
+	}
+	origRoleMappings := []config.RoleMapping{
+		{
+			RoleARN:  "arn:aws:iam::000000000098:role/KubernetesAdmin",
+			Username: "kubernetes-admin",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	origAccounts := []string{"012345678901", "456789012345"}
+
+	if !reflect.DeepEqual(u, origUserMappings) {
+		t.Fatalf("unexpected userMappings %+v", u)
+	}
+	if !reflect.DeepEqual(r, origRoleMappings) {
+		t.Fatalf("unexpected roleMappings %+v", r)
+	}
+	if !reflect.DeepEqual(a, origAccounts) {
+		t.Fatalf("unexpected accounts %+v", a)
+	}
+	//clean testing files
+	defer os.Remove("/tmp/test.txt")
+
+}

--- a/pkg/mapper/dynamicfile/mapper.go
+++ b/pkg/mapper/dynamicfile/mapper.go
@@ -1,0 +1,59 @@
+package dynamicfile
+
+import (
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
+	"strings"
+)
+
+type DynamicFileMapper struct {
+	*DynamicFileMapStore
+}
+
+var _ mapper.Mapper = &DynamicFileMapper{}
+
+func NewDynamicFileMapper(cfg config.Config) (*DynamicFileMapper, error) {
+	ms, err := NewDynamicFileMapStore(cfg.DynamicFilePath)
+	if err != nil {
+		return nil, err
+	}
+	return &DynamicFileMapper{ms}, nil
+}
+
+func (m *DynamicFileMapper) Name() string {
+	return mapper.ModeDynamicFile
+}
+
+func (m *DynamicFileMapper) Start(stopCh <-chan struct{}) error {
+	m.startLoadDynamicFile(stopCh)
+	return nil
+}
+
+func (m *DynamicFileMapper) Map(canonicalARN string) (*config.IdentityMapping, error) {
+	canonicalARN = strings.ToLower(canonicalARN)
+
+	rm, err := m.RoleMapping(canonicalARN)
+	// TODO: Check for non Role/UserNotFound errors
+	if err == nil {
+		return &config.IdentityMapping{
+			IdentityARN: canonicalARN,
+			Username:    rm.Username,
+			Groups:      rm.Groups,
+		}, nil
+	}
+
+	um, err := m.UserMapping(canonicalARN)
+	if err == nil {
+		return &config.IdentityMapping{
+			IdentityARN: canonicalARN,
+			Username:    um.Username,
+			Groups:      um.Groups,
+		}, nil
+	}
+
+	return nil, mapper.ErrNotMapped
+}
+
+func (m *DynamicFileMapper) IsAccountAllowed(accountID string) bool {
+	return m.AWSAccount(accountID)
+}

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -20,15 +20,17 @@ const (
 	ModeEKSConfigMap string = "EKSConfigMap"
 
 	ModeCRD string = "CRD"
+
+	ModeDynamicFile string = "DynamicFile"
 )
 
 var (
-	ValidBackendModeChoices      = []string{ModeFile, ModeConfigMap, ModeMountedFile, ModeEKSConfigMap, ModeCRD}
+	ValidBackendModeChoices      = []string{ModeFile, ModeConfigMap, ModeMountedFile, ModeEKSConfigMap, ModeCRD, ModeDynamicFile}
 	DeprecatedBackendModeChoices = map[string]string{
 		ModeFile:      ModeMountedFile,
 		ModeConfigMap: ModeEKSConfigMap,
 	}
-	BackendModeChoices = []string{ModeMountedFile, ModeEKSConfigMap, ModeCRD}
+	BackendModeChoices = []string{ModeMountedFile, ModeEKSConfigMap, ModeCRD, ModeDynamicFile}
 )
 
 var ErrNotMapped = errors.New("ARN is not mapped")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/configmap"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/crd"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/dynamicfile"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/file"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
@@ -220,6 +221,12 @@ func BuildMapperChain(cfg config.Config) ([]mapper.Mapper, error) {
 				return nil, fmt.Errorf("backend-mode %q creation failed: %v", mode, err)
 			}
 			mappers = append(mappers, crdMapper)
+		case mapper.ModeDynamicFile:
+			dynamicFileMapper, err := dynamicfile.NewDynamicFileMapper(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("backend-mode %q creation failed: %v", mode, err)
+			}
+			mappers = append(mappers, dynamicFileMapper)
 		default:
 			return nil, fmt.Errorf("backend-mode %q is not a valid mode", mode)
 		}


### PR DESCRIPTION
Description:

This PR introduces a new backend mode DYNAMICFILE and an according DYNAMICFILEPATH configurable option to authenticator. It will enable authenticator to load the identity and its mapping from a file specified by DYNAMICFILEPATH  and dynamically reload whenever there is any change in the file.

- [x] make test
- [X] make start-dev-env
- [ ] hack/run/e2e
