### PR TITLE
 bubble up GOPROXY=direct environment value to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroo
 FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-iam-authenticator
 COPY . .
-RUN go mod download
+RUN GOPROXY=direct go mod download
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make bin
 RUN chown 65532 _output/bin/aws-iam-authenticator
 


### PR DESCRIPTION
## Summary
Some VPNs or networks block proxies or caches for golang package artifactories. This change bubbles up the GOPROXY settings in the user's environment to the build in the dockerfile.

## Testing
I set GOPROXY to `direct` and `https://goproxy.io`, respectfully:

```
GOPROXY=direct make image
docker buildx build \
                --output=type=docker \
                --platform linux/amd64 \
                --build-arg GOPROXY=direct \
                --tag aws-iam-authenticator:v0.6.0-alpha.0_67db2c300e99b98897f3b7bc61b546619129963e_20220924T024600Z .

…
[+] Building 918.6s (17/17) FINISHED
```

```
GOPROXY="https://goproxy.io" make image
docker buildx build \
                --output=type=docker \
                --platform linux/amd64 \
                --build-arg GOPROXY=https://goproxy.io \
                --tag aws-iam-authenticator:v0.6.0-alpha.0_67db2c300e99b98897f3b7bc61b546619129963e_20220924T164456Z .
[+] Building 402.9s (17/17) FINISHED
```

Omitting the `GOPROXY` variable entirely works as well.