### PR TITLE
Print version on startup

### DIFF
--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 
+	"sigs.k8s.io/aws-iam-authenticator/pkg"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 
@@ -86,6 +87,9 @@ func initConfig() {
 }
 
 func getConfig() (config.Config, error) {
+
+	fmt.Printf("Authenticator Version: %q\n", pkg.Version)
+
 	cfg := config.Config{
 		PartitionID:                       viper.GetString("server.partition"),
 		ClusterID:                         viper.GetString("clusterID"),


### PR DESCRIPTION
Print version on startup so that its clear what version is running when looking at logs. 