### PR TITLE
WIP update Dockerfile to use Golang 1.19 as builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 ARG image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-12-01-1638322424
 
-FROM --platform=$BUILDPLATFORM golang:1.16 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-iam-authenticator
 COPY . .
 RUN go mod download


### PR DESCRIPTION
Update Dockerfile to use Golang 1.19 as builder
/assign wongma7