### PR TITLE
remove dependency from PR #416

### DIFF
--- a/pkg/mapper/dynamicfile/dynamicfile_test.go
+++ b/pkg/mapper/dynamicfile/dynamicfile_test.go
@@ -22,7 +22,7 @@ func makeStore() DynamicFileMapStore {
 		filename:    "test.txt",
 	}
 	ms.users["arn:aws:iam::012345678912:user/matt"] = testUser
-	ms.roles["arn:aws:iam::012345678912:role/comp*"] = testRole
+	ms.roles["arn:aws:iam::012345678912:role/computer"] = testRole
 	ms.awsAccounts["123"] = nil
 	return ms
 }


### PR DESCRIPTION
this PR remove the invocation of methods introduced in PR #416 because PR #416 has specific SSO role suffix support.

In order to verify end to end, run `make start-dev-dynamicfile`, testing should succeed.