### PR TITLE
fix Makefile on branch release-0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build-all-bins:
 
 .PHONY: image
 image:
-	docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 \
+	docker buildx build --output=type=docker --platform linux/amd64 \
 		--tag aws-iam-authenticator:$(VERSION)_$(GIT_COMMIT)_$(BUILD_DATE_STRIPPED) .
 
 .PHONY: goreleaser


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the Makefile from below error

docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 \
	--tag aws-iam-authenticator:v0.5.11_5848ac2e8a0b25c2fed5d1f5eaf6f08dd20e6bcb_20221123T210711Z .
ERROR: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
make[1]: *** [Makefile:83: image] Error 1
make[1]: Leaving directory '/home/prow/go/src/github.com/kubernetes-sigs/aws-iam-authenticator'
make: *** [Makefile:107: e2e] Error 2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

