### PR TITLE
Enable Mapping on UserID

### DIFF
--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -104,6 +104,7 @@ func getConfig() (config.Config, error) {
 		EC2DescribeInstancesBurst:         viper.GetInt("server.ec2DescribeInstancesBurst"),
 		ScrubbedAWSAccounts:               viper.GetStringSlice("server.scrubbedAccounts"),
 		DynamicFilePath:                   viper.GetString("server.dynamicfilepath"),
+		DynamicFileUserIDStrict:           viper.GetBool("server.dynamicfileUserIDStrict"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &cfg.RoleMappings); err != nil {
 		return cfg, fmt.Errorf("invalid server role mappings: %v", err)

--- a/hack/dev/access-entries.template
+++ b/hack/dev/access-entries.template
@@ -5,7 +5,8 @@
       "username": "kubernetes-admin",
       "groups": [
         "system:masters"
-      ]
+      ],
+      "userid": "{{USER_ID}}"
     }
   ]
 }

--- a/hack/e2e-dynamicfile.sh
+++ b/hack/e2e-dynamicfile.sh
@@ -103,7 +103,8 @@ function e2e_dynamicfile(){
           echo "can't assume-role: "${AWS_TEST_ROLE}
           exit 1
   fi
-
+  USERID=$(aws sts get-caller-identity|jq -r '.UserId'|cut -d: -f1)
+  echo "userid: " $USERID
   #run kubectl cmd without adding the role into access entry
   if [ -f ${access_entry_json} ]
       then
@@ -123,6 +124,7 @@ function e2e_dynamicfile(){
 
   sed -e "s|{{AWS_ACCOUNT}}|${AWS_ACCOUNT}|g" \
       -e "s|{{AWS_TEST_ROLE}}|${AWS_TEST_ROLE}|g" \
+      -e "s|{{USER_ID}}|${USERID}|g" \
             "${access_entry_template}" > "${access_entry_tmp}"
   mv "${access_entry_tmp}"  "${access_entry_json}"
   #sleep 10 seconds to make access entry effective

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -57,6 +57,9 @@ type RoleMapping struct {
 	// Groups is a list of Kubernetes groups this role will authenticate
 	// as (e.g., `system:masters`). Each group name can include placeholders.
 	Groups []string `json:"groups" yaml:"groups"`
+
+	// UserId is the AWS PrincipalId of the role. (e.g., "ABCXSOTJDDV").
+	UserId string `json:"userid,omitempty" yaml:"userid,omitempty"`
 }
 
 // UserMapping is a static mapping of a single AWS User ARN to a
@@ -70,6 +73,9 @@ type UserMapping struct {
 
 	// Groups is a list of Kubernetes groups this role will authenticate as (e.g., `system:masters`)
 	Groups []string `json:"groups" yaml:"groups"`
+
+	// UserId is the AWS PrincipalId of the user. (e.g., "ABCXSOTJDDV").
+	UserId string `json:"userid,omitempty" yaml:"userid,omitempty"`
 }
 
 // SSOARNMatcher contains fields used to match Role ARNs that
@@ -171,4 +177,6 @@ type Config struct {
 	EC2DescribeInstancesBurst int
 	//Dynamic File Path for DynamicFile BackendMode
 	DynamicFilePath string
+	//use UserId for mapping, IdentityArn is not used any more when DynamicFileUserIDStrict=true
+	DynamicFileUserIDStrict bool
 }

--- a/pkg/mapper/configmap/mapper.go
+++ b/pkg/mapper/configmap/mapper.go
@@ -1,6 +1,7 @@
 package configmap
 
 import (
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 	"strings"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
@@ -30,8 +31,8 @@ func (m *ConfigMapMapper) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (m *ConfigMapMapper) Map(canonicalARN string) (*config.IdentityMapping, error) {
-	canonicalARN = strings.ToLower(canonicalARN)
+func (m *ConfigMapMapper) Map(identity *token.Identity) (*config.IdentityMapping, error) {
+	canonicalARN := strings.ToLower(identity.CanonicalARN)
 
 	rm, err := m.RoleMapping(canonicalARN)
 	// TODO: Check for non Role/UserNotFound errors

--- a/pkg/mapper/crd/mapper.go
+++ b/pkg/mapper/crd/mapper.go
@@ -2,6 +2,7 @@ package crd
 
 import (
 	"fmt"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 	"strings"
 	"time"
 
@@ -86,8 +87,8 @@ func (m *CRDMapper) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (m *CRDMapper) Map(canonicalARN string) (*config.IdentityMapping, error) {
-	canonicalARN = strings.ToLower(canonicalARN)
+func (m *CRDMapper) Map(identity *token.Identity) (*config.IdentityMapping, error) {
+	canonicalARN := strings.ToLower(identity.CanonicalARN)
 
 	var iamidentity *iamauthenticatorv1alpha1.IAMIdentityMapping
 	var ok bool

--- a/pkg/mapper/file/mapper_test.go
+++ b/pkg/mapper/file/mapper_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"reflect"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 	"testing"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
@@ -98,12 +99,15 @@ func TestMap(t *testing.T) {
 	}
 
 	identityArn := "arn:aws:iam::012345678910:role/test-role"
+	identity := token.Identity{
+		CanonicalARN: identityArn,
+	}
 	expected := &config.IdentityMapping{
 		IdentityARN: identityArn,
 		Username:    "shreyas",
 		Groups:      []string{"system:masters"},
 	}
-	actual, err := fm.Map(identityArn)
+	actual, err := fm.Map(&identity)
 	if err != nil {
 		t.Errorf("Could not map %s: %s", identityArn, err)
 	}
@@ -112,12 +116,15 @@ func TestMap(t *testing.T) {
 	}
 
 	identityArn = "arn:aws:iam::012345678910:role/awsreservedsso_cookiecutterpermissions_123123123"
+	identity = token.Identity{
+		CanonicalARN: identityArn,
+	}
 	expected = &config.IdentityMapping{
 		IdentityARN: identityArn,
 		Username:    "cookie-cutter",
 		Groups:      []string{"system:masters"},
 	}
-	actual, err = fm.Map(identityArn)
+	actual, err = fm.Map(&identity)
 	if err != nil {
 		t.Errorf("Could not map %s: %s", identityArn, err)
 	}
@@ -126,12 +133,15 @@ func TestMap(t *testing.T) {
 	}
 
 	identityArn = "arn:aws:iam::012345678910:user/donald"
+	identity = token.Identity{
+		CanonicalARN: identityArn,
+	}
 	expected = &config.IdentityMapping{
 		IdentityARN: identityArn,
 		Username:    "donald",
 		Groups:      []string{"system:masters"},
 	}
-	actual, err = fm.Map(identityArn)
+	actual, err = fm.Map(&identity)
 	if err != nil {
 		t.Errorf("Could not map %s: %s", identityArn, err)
 	}

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"errors"
 	"fmt"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -39,7 +40,7 @@ type Mapper interface {
 	Name() string
 	// Start must be non-blocking
 	Start(stopCh <-chan struct{}) error
-	Map(canonicalARN string) (*config.IdentityMapping, error)
+	Map(identity *token.Identity) (*config.IdentityMapping, error)
 	IsAccountAllowed(accountID string) bool
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -368,10 +368,8 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 func (h *handler) doMapping(identity *token.Identity) (string, []string, error) {
 	var errs []error
 
-	canonicalARN := strings.ToLower(identity.CanonicalARN)
-
 	for _, m := range h.mappers {
-		mapping, err := m.Map(canonicalARN)
+		mapping, err := m.Map(identity)
 		if err == nil {
 			// Mapping found, try to render any templates like {{EC2PrivateDNSName}}
 			username, groups, err := h.renderTemplates(*mapping, identity)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
1. this PR add UserId lookup in the RoleMapping for dynamic file
2. this PR fix the User mapping failure introduced by https://github.com/kubernetes-sigs/aws-iam-authenticator/commit/55005e174cfca7eb5538b5dedfc409cca9be6d1a#diff-4dfc68b8a5ed36d024d6f6626d8aa66132e3c5702e882182396fbbcb1299cf01R40

bug explaination:

https://github.com/kubernetes-sigs/aws-iam-authenticator/commit/55005e174cfca7eb5538b5dedfc409cca9be6d1a#diff-4dfc68b8a5ed36d024d6f6626d8aa66132e3c5702e882182396fbbcb1299cf01R40 didn't update m.UserARN to canonicalizedARN. When it compares the UserARN, it only lower case the m.UserARN, but didn't call canonicalize either. https://github.com/kubernetes-sigs/aws-iam-authenticator/commit/55005e174cfca7eb5538b5dedfc409cca9be6d1a#diff-7f58544dd05343616eb8d9d780c0989085cb17cbd650375495ce8152bc872642R118

This caused lookup failure because the server always pass in canonicalizedARN. https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/pkg/server/server.go#L379
 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

