### PR TITLE
Add default instance region in sts hostname

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/ec2provider"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
@@ -185,10 +187,16 @@ func (c *Server) getHandler(mappers []mapper.Mapper, ec2DescribeQps int, ec2Desc
 			panic(fmt.Sprintf("describeinstancesrole %s is not a valid arn", c.ServerEC2DescribeInstancesRoleARN))
 		}
 	}
+	sess := session.Must(session.NewSession())
+	ec2metadata := ec2metadata.New(sess)
+	instanceRegion, err := ec2metadata.Region()
+	if err != nil {
+		logrus.WithError(err).Errorln("Region not found in instance metadata.")
+	}
 
 	h := &handler{
-		verifier:         token.NewVerifier(c.ClusterID, c.PartitionID),
-		ec2Provider:      ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, ec2DescribeQps, ec2DescribeBurst),
+		verifier:         token.NewVerifier(c.ClusterID, c.PartitionID, instanceRegion),
+		ec2Provider:      ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
 		clusterID:        c.ClusterID,
 		mappers:          mappers,
 		scrubbedAccounts: c.Config.ScrubbedAWSAccounts,

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -94,6 +94,7 @@ const (
 	dateHeaderFormat   = "20060102T150405Z"
 	kindExecCredential = "ExecCredential"
 	execInfoEnvKey     = "KUBERNETES_EXEC_INFO"
+	stsServiceID       = "sts"
 )
 
 // Token is generated and used by Kubernetes client-go to authenticate with a Kubernetes cluster.
@@ -377,7 +378,7 @@ type tokenVerifier struct {
 	validSTShostnames map[string]bool
 }
 
-func stsHostsForPartition(partitionID string) map[string]bool {
+func stsHostsForPartition(partitionID, region string) map[string]bool {
 	validSTShostnames := map[string]bool{}
 
 	var partition *endpoints.Partition
@@ -391,12 +392,14 @@ func stsHostsForPartition(partitionID string) map[string]bool {
 		logrus.Errorf("Partition %s not valid", partitionID)
 		return validSTShostnames
 	}
-	stsSvc, ok := partition.Services()["sts"]
+
+	stsSvc, ok := partition.Services()[stsServiceID]
 	if !ok {
 		logrus.Errorf("STS service not found in partition %s", partitionID)
 		return validSTShostnames
 	}
-	for epName, ep := range stsSvc.Endpoints() {
+	stsSvcEndPoints := stsSvc.Endpoints()
+	for epName, ep := range stsSvcEndPoints {
 		rep, err := ep.ResolveEndpoint(endpoints.STSRegionalEndpointOption)
 		if err != nil {
 			logrus.WithError(err).Errorf("Error resolving endpoint for %s in partition %s", epName, partitionID)
@@ -409,16 +412,34 @@ func stsHostsForPartition(partitionID string) map[string]bool {
 		}
 		validSTShostnames[parsedURL.Hostname()] = true
 	}
+
+	// Add the host of the current instances region if not already exists so we don't fail if the region is not
+	// present in the go sdk but matches the instances region.
+	if _, ok := stsSvcEndPoints[region]; !ok {
+		rep, err := partition.EndpointFor(stsServiceID, region, endpoints.STSRegionalEndpointOption)
+		if err != nil {
+			logrus.WithError(err).Errorf("Error resolving endpoint for %s in partition %s", region, partitionID)
+			return validSTShostnames
+		}
+		parsedURL, err := url.Parse(rep.URL)
+		if err != nil {
+			logrus.WithError(err).Errorf("Error parsing STS URL %s", rep.URL)
+			return validSTShostnames
+		}
+		validSTShostnames[parsedURL.Hostname()] = true
+	}
+
 	return validSTShostnames
 }
 
 // NewVerifier creates a Verifier that is bound to the clusterID and uses the default http client.
-func NewVerifier(clusterID string, partitionID string) Verifier {
+func NewVerifier(clusterID, partitionID, region string) Verifier {
 	// Initialize metrics if they haven't already been initialized to avoid a
 	// nil pointer panic when setting metric values.
 	if !metrics.Initialized() {
 		metrics.InitMetrics(prometheus.NewRegistry())
 	}
+
 	return tokenVerifier{
 		client: &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -426,7 +447,7 @@ func NewVerifier(clusterID string, partitionID string) Verifier {
 			},
 		},
 		clusterID:         clusterID,
-		validSTShostnames: stsHostsForPartition(partitionID),
+		validSTShostnames: stsHostsForPartition(partitionID, region),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR will validate if the token hostname if it matches the instances metadata region even though if the endpoint is not part of the aws-sdk-go static config. This will help in removing the dependency on updating the sdk-go every time a new AWS region comes up. We are doing similar fallback check both in the [aws cloud provider](https://github.com/kubernetes/cloud-provider-aws/blob/master/pkg/providers/v1/aws.go#L1484) and in [k8s  code](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1435).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

