### PR TITLE
Build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ $(OUTPUT)/bin/%: $(SOURCES)
 		GOARCH=$(GOARCH) \
 		GOPROXY=$(GOPROXY) \
 		go build \
+		--tags "$(GOTAGS)" \
 		-o=$@ \
 		-ldflags="-w -s -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.BuildDate=$(BUILD_DATE) -X $(PKG)/pkg.CommitID=$(GIT_COMMIT)" \
 		./cmd/aws-iam-authenticator/

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ $(OUTPUT)/bin/%: $(SOURCES)
 		GOARCH=$(GOARCH) \
 		GOPROXY=$(GOPROXY) \
 		go build \
+		-trimpath \
 		--tags "$(GOTAGS)" \
 		-o=$@ \
 		-ldflags="-w -s -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.BuildDate=$(BUILD_DATE) -X $(PKG)/pkg.CommitID=$(GIT_COMMIT)" \

--- a/cmd/aws-iam-authenticator/add.go
+++ b/cmd/aws-iam-authenticator/add.go
@@ -1,3 +1,4 @@
+//go:build !no_add
 /*
 Copyright 2021 by the contributors.
 

--- a/cmd/aws-iam-authenticator/init.go
+++ b/cmd/aws-iam-authenticator/init.go
@@ -1,3 +1,4 @@
+//go:build !no_init
 /*
 Copyright 2017 by the contributors.
 

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -1,3 +1,4 @@
+//go:build !no_server
 /*
 Copyright 2017 by the contributors.
 

--- a/cmd/aws-iam-authenticator/token.go
+++ b/cmd/aws-iam-authenticator/token.go
@@ -1,3 +1,4 @@
+//go:build !no_token
 /*
 Copyright 2017 by the contributors.
 

--- a/cmd/aws-iam-authenticator/verify.go
+++ b/cmd/aws-iam-authenticator/verify.go
@@ -1,3 +1,4 @@
+//go:build !no_verify
 /*
 Copyright 2017 by the contributors.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes two changes to the build system:
1. The go build command is called with `-trimpath` to strip host build specific prefixes from the debug paths embedded into the final binary
2. The Makefile supports injecting in optional `GOTAGS` to affect the build. Tags have been added to optionally exclude each of the sub commands (except `help` and `version`). For normal builds, this has no effect, as the default remains to build all. However it allows users who are custom building the binary for specific purposes to exclude features which are not required.

