### PR TITLE
Allow running create release from github UI

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,7 @@
 # Github Action to create a release with goreleaser
 name: Create Release
 on:
+  workflow_dispatch:
   push:
     # Sequence of patterns matched against refs/tags
     tags:


### PR DESCRIPTION
We have a lot of tags with no corresponding release. So trying to figure out how to get them back.