### PR TITLE
Avoid parsing known empty inputs

### DIFF
--- a/pkg/mapper/configmap/configmap_test.go
+++ b/pkg/mapper/configmap/configmap_test.go
@@ -331,3 +331,25 @@ func TestParseMap(t *testing.T) {
 		t.Fatalf("unexpected %v != %v", m1, m2)
 	}
 }
+
+func TestBadParseMap(t *testing.T) {
+	m1 := map[string]string{
+		"mapAccounts": ``,
+		"mapRoles":    `""`,
+		"mapUsers":    "``",
+	}
+
+	u, r, a, err := ParseMap(m1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := EncodeMap(u, r, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyMap := map[string]string{}
+	if !reflect.DeepEqual(emptyMap, m2) {
+		t.Fatalf("unexpected %v != %v", emptyMap, m2)
+	}
+}


### PR DESCRIPTION
We are seeing instances of the configmap in the wild with variations like below:

```
apiVersion: v1
data:
mapAccounts: |
    ''
mapUsers: |
    ""
```

We should tolerate these as the user literally means, there's no data they need in there.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

