### PR TITLE
Avoid parsing known empty inputs

### DIFF
--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -3,7 +3,6 @@ package configmap
 import (
 	"context"
 	"errors"
-	"strings"
 	"sync"
 
 	"fmt"
@@ -119,23 +118,9 @@ func ParseMap(m map[string]string) (userMappings []config.UserMapping, roleMappi
 	userMappings = make([]config.UserMapping, 0)
 	if userData, ok := m["mapUsers"]; ok {
 		if !isSkippable(userData) {
-			userJson, err := utilyaml.ToJSON([]byte(userData))
+			err := yaml.Unmarshal([]byte(userData), &userMappings)
 			if err != nil {
 				errs = append(errs, err)
-			} else {
-				err = json.Unmarshal(userJson, &rawUserMappings)
-				if err != nil {
-					errs = append(errs, err)
-				}
-
-				for _, userMapping := range rawUserMappings {
-					err = userMapping.Validate()
-					if err != nil {
-						errs = append(errs, err)
-					} else {
-						userMappings = append(userMappings, userMapping)
-					}
-				}
 			}
 		}
 	}
@@ -143,23 +128,9 @@ func ParseMap(m map[string]string) (userMappings []config.UserMapping, roleMappi
 	roleMappings = make([]config.RoleMapping, 0)
 	if roleData, ok := m["mapRoles"]; ok {
 		if !isSkippable(roleData) {
-			roleJson, err := utilyaml.ToJSON([]byte(roleData))
+			err := yaml.Unmarshal([]byte(roleData), &roleMappings)
 			if err != nil {
 				errs = append(errs, err)
-			} else {
-				err = json.Unmarshal(roleJson, &rawRoleMappings)
-				if err != nil {
-					errs = append(errs, err)
-				}
-
-				for _, roleMapping := range rawRoleMappings {
-					err = roleMapping.Validate()
-					if err != nil {
-						errs = append(errs, err)
-					} else {
-						roleMappings = append(roleMappings, roleMapping)
-					}
-				}
 			}
 		}
 	}

--- a/pkg/mapper/configmap/configmap_test.go
+++ b/pkg/mapper/configmap/configmap_test.go
@@ -285,3 +285,25 @@ func TestParseMap(t *testing.T) {
 		t.Fatalf("unexpected %v != %v", m1, m2)
 	}
 }
+
+func TestBadParseMap(t *testing.T) {
+	m1 := map[string]string{
+		"mapAccounts": ``,
+		"mapRoles":    `""`,
+		"mapUsers":    "``",
+	}
+
+	u, r, a, err := ParseMap(m1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := EncodeMap(u, r, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyMap := map[string]string{}
+	if !reflect.DeepEqual(emptyMap, m2) {
+		t.Fatalf("unexpected %v != %v", emptyMap, m2)
+	}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/618/ to add to 0.5 release

**What this PR does / why we need it**:
We are seeing instances of the configmap in the wild with variations like below:

```
apiVersion: v1
data:
mapAccounts: |
    ''
mapUsers: |
    ""
```
We should tolerate these as the user literally means, there's no data they need in there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

