### PR TITLE
Avoid parsing single quote empty inputs

### DIFF
--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -184,7 +184,7 @@ func ParseMap(m map[string]string) (userMappings []config.UserMapping, roleMappi
 
 func isSkippable(data string) bool {
 	trimmed := strings.TrimSpace(data)
-	return trimmed == "" || trimmed == "``" || trimmed == "\"\""
+	return trimmed == "" || trimmed == "``" || trimmed == "\"\"" || trimmed == "''"
 }
 
 func EncodeMap(userMappings []config.UserMapping, roleMappings []config.RoleMapping, awsAccounts []string) (m map[string]string, err error) {

--- a/pkg/mapper/configmap/configmap_test.go
+++ b/pkg/mapper/configmap/configmap_test.go
@@ -353,3 +353,25 @@ func TestBadParseMap(t *testing.T) {
 		t.Fatalf("unexpected %v != %v", emptyMap, m2)
 	}
 }
+
+func TestBadParseMapSingleQuote(t *testing.T) {
+	m1 := map[string]string{
+		"mapAccounts": `''`,
+		"mapRoles":    `''`,
+		"mapUsers":    `''`,
+	}
+
+	u, r, a, err := ParseMap(m1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := EncodeMap(u, r, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyMap := map[string]string{}
+	if !reflect.DeepEqual(emptyMap, m2) {
+		t.Fatalf("unexpected %v != %v", emptyMap, m2)
+	}
+}


### PR DESCRIPTION
Enhancement of https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/618 to not parse when single quote quotation marks are present. Like the following:
```
apiVersion: v1
data:
mapAccounts: |
    ''
mapUsers: |
    ''
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

