### PR TITLE
Avoid parsing empty 6

### DIFF
--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -117,35 +117,41 @@ func ParseMap(m map[string]string) (userMappings []config.UserMapping, roleMappi
 	errs := make([]error, 0)
 	userMappings = make([]config.UserMapping, 0)
 	if userData, ok := m["mapUsers"]; ok {
-		userJson, err := utilyaml.ToJSON([]byte(userData))
-		if err != nil {
-			errs = append(errs, err)
-		} else {
-			err = json.Unmarshal(userJson, &userMappings)
+		if !isSkippable(userData) {
+			userJson, err := utilyaml.ToJSON([]byte(userData))
 			if err != nil {
 				errs = append(errs, err)
+			} else {
+				err = json.Unmarshal(userJson, &userMappings)
+				if err != nil {
+					errs = append(errs, err)
+				}
 			}
 		}
 	}
 
 	roleMappings = make([]config.RoleMapping, 0)
 	if roleData, ok := m["mapRoles"]; ok {
-		roleJson, err := utilyaml.ToJSON([]byte(roleData))
-		if err != nil {
-			errs = append(errs, err)
-		} else {
-			err = json.Unmarshal(roleJson, &roleMappings)
+		if !isSkippable(roleData) {
+			roleJson, err := utilyaml.ToJSON([]byte(roleData))
 			if err != nil {
 				errs = append(errs, err)
+			} else {
+				err = json.Unmarshal(roleJson, &roleMappings)
+				if err != nil {
+					errs = append(errs, err)
+				}
 			}
 		}
 	}
 
 	awsAccounts = make([]string, 0)
 	if accountsData, ok := m["mapAccounts"]; ok {
-		err := yaml.Unmarshal([]byte(accountsData), &awsAccounts)
-		if err != nil {
-			errs = append(errs, err)
+		if !isSkippable(accountsData) {
+			err := yaml.Unmarshal([]byte(accountsData), &awsAccounts)
+			if err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 
@@ -154,6 +160,11 @@ func ParseMap(m map[string]string) (userMappings []config.UserMapping, roleMappi
 		err = ErrParsingMap{errors: errs}
 	}
 	return userMappings, roleMappings, awsAccounts, err
+}
+
+func isSkippable(data string) bool {
+	trimmed := strings.TrimSpace(data)
+	return trimmed == "" || trimmed == "``" || trimmed == "\"\""
 }
 
 func EncodeMap(userMappings []config.UserMapping, roleMappings []config.RoleMapping, awsAccounts []string) (m map[string]string, err error) {

--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -164,7 +164,7 @@ func ParseMap(m map[string]string) (userMappings []config.UserMapping, roleMappi
 
 func isSkippable(data string) bool {
 	trimmed := strings.TrimSpace(data)
-	return trimmed == "" || trimmed == "``" || trimmed == "\"\""
+	return trimmed == "" || trimmed == "``" || trimmed == "\"\"" || trimmed == "''"
 }
 
 func EncodeMap(userMappings []config.UserMapping, roleMappings []config.RoleMapping, awsAccounts []string) (m map[string]string, err error) {

--- a/pkg/mapper/configmap/configmap_test.go
+++ b/pkg/mapper/configmap/configmap_test.go
@@ -307,3 +307,25 @@ func TestBadParseMap(t *testing.T) {
 		t.Fatalf("unexpected %v != %v", emptyMap, m2)
 	}
 }
+
+func TestBadParseMapSingleQuote(t *testing.T) {
+	m1 := map[string]string{
+		"mapAccounts": `''`,
+		"mapRoles":    `''`,
+		"mapUsers":    `''`,
+	}
+
+	u, r, a, err := ParseMap(m1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := EncodeMap(u, r, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyMap := map[string]string{}
+	if !reflect.DeepEqual(emptyMap, m2) {
+		t.Fatalf("unexpected %v != %v", emptyMap, m2)
+	}
+}

--- a/pkg/mapper/configmap/configmap_test.go
+++ b/pkg/mapper/configmap/configmap_test.go
@@ -285,3 +285,25 @@ func TestParseMap(t *testing.T) {
 		t.Fatalf("unexpected %v != %v", m1, m2)
 	}
 }
+
+func TestBadParseMap(t *testing.T) {
+	m1 := map[string]string{
+		"mapAccounts": ``,
+		"mapRoles":    `""`,
+		"mapUsers":    "``",
+	}
+
+	u, r, a, err := ParseMap(m1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := EncodeMap(u, r, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyMap := map[string]string{}
+	if !reflect.DeepEqual(emptyMap, m2) {
+		t.Fatalf("unexpected %v != %v", emptyMap, m2)
+	}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/618 and https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/621 to add to 0.6 release

**What this PR does / why we need it**:
We are seeing instances of the configmap in the wild with variations like below:
```
apiVersion: v1
data:
mapAccounts: |
    ''
mapUsers: |
    ""
```
We should tolerate these as the user literally means, there's no data they need in there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

