### PR TITLE
Update the link of #client-go-credential-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ about how to configure the reserved prefix.
 
 Finally, once the server is set up you'll want to authenticate.
 You will still need a `kubeconfig` that has the public data about your cluster (cluster CA certificate, endpoint address).
-The `users` section of your configuration, however, should include an exec section ([refer to the v1.10 docs](https://kubernetes.io/docs/admin/authentication/#client-go-credential-plugins))::
+The `users` section of your configuration, however, should include an exec section ([refer to the v1.22 docs](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins))::
 ```yaml
 # [...]
 users:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The [link](https://kubernetes.io/docs/admin/authentication/#client-go-credential-plugins) of `client-go credential plugins` gives 404 error. 
Updated the link to the latest [version](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins).

**Which issue(s) this PR fixes** 
Fixes #

