### PR TITLE
Optionally return full role arn including path during token verification

### DIFF
--- a/pkg/token/rolecache.go
+++ b/pkg/token/rolecache.go
@@ -1,0 +1,103 @@
+package token
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
+
+type IAMClient interface {
+	ListRolesPages(input *iam.ListRolesInput, fn func(*iam.ListRolesOutput, bool) bool) error
+}
+
+// RoleCache Cache on first use IAM role cache which stores a map of Role ID -> ARN for lookup during verify
+// operations. This solves the issue of assume-role ARNs not including the assumed role's path.
+type RoleCache struct {
+	awsClient   IAMClient
+	searchRoles bool
+	lastUpdate  time.Time
+	idToFullARN map[string]string
+	mutex       sync.RWMutex
+}
+
+// NewRoleCache Creates a RoleCache and returns it.
+func NewRoleCache() *RoleCache {
+	sess, err := session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable})
+	var iamClient *iam.IAM
+	if err != nil {
+		logrus.WithError(err).Warn("failed to instantiate AWS session, disabling full role ARN lookup")
+	} else {
+		iamClient = iam.New(sess)
+	}
+
+	return &RoleCache{
+		awsClient:   iamClient,
+		searchRoles: iamClient != nil,
+		lastUpdate:  time.Now().Add(-10 * time.Minute),
+		idToFullARN: make(map[string]string),
+		mutex:       sync.RWMutex{},
+	}
+}
+
+// updateRoles Calls IAM ListRoles and updates the idToFullARN map.
+func (r *RoleCache) updateRoles() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.lastUpdate = time.Now()
+
+	newARNMap := make(map[string]string)
+
+	err := r.awsClient.ListRolesPages(&iam.ListRolesInput{}, func(output *iam.ListRolesOutput, b bool) bool {
+		for _, role := range output.Roles {
+			newARNMap[*role.RoleId] = *role.Arn
+		}
+		return true
+	})
+	if err != nil {
+		var aerr awserr.Error
+		if errors.As(err, &aerr) {
+			// If we don't have credentials or have access to ListRole then cancel searching roles in future
+			switch aerr.Code() {
+			case "NoCredentialProviders":
+				logrus.WithError(aerr).Error("no credentials found to list IAM roles with, disabling role cache")
+				r.searchRoles = false
+			case "AccessDenied":
+				logrus.WithError(aerr).Error("no access to IAM list role, disabling role cache")
+				r.searchRoles = false
+			default:
+				// Treat as transient error
+				logrus.WithError(aerr).Error("transient IAM role list failure")
+			}
+		} else {
+			// Non aws error
+			logrus.WithError(err).Error("failed to list IAM roles")
+			r.searchRoles = false
+		}
+
+		return
+	}
+
+	r.idToFullARN = newARNMap
+}
+
+// CheckRoleID Takes a unique role ID and returns an ARN if found.
+func (r *RoleCache) CheckRoleID(roleID string) (string, bool) {
+	if !r.searchRoles {
+		return "", false
+	}
+
+	if time.Now().Sub(r.lastUpdate) > 5*time.Minute {
+		r.updateRoles()
+	}
+
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	roleARN, exists := r.idToFullARN[roleID]
+	return roleARN, exists
+}

--- a/pkg/token/rolecache_test.go
+++ b/pkg/token/rolecache_test.go
@@ -1,0 +1,133 @@
+package token
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"testing"
+)
+
+type mockIAM struct {
+	Called int
+	Pages  []*iam.ListRolesOutput
+	Err    error
+}
+
+func (m *mockIAM) ListRolesPages(input *iam.ListRolesInput, fn func(*iam.ListRolesOutput, bool) bool) error {
+	m.Called++
+
+	if m.Err != nil {
+		return m.Err
+	}
+
+	lastItem := len(m.Pages) - 1
+	for index, page := range m.Pages {
+		fn(page, index == lastItem)
+	}
+
+	return nil
+}
+
+func getMockedRoleCache() (*RoleCache, *mockIAM) {
+	r := NewRoleCache()
+	m := &mockIAM{
+		Pages: make([]*iam.ListRolesOutput, 0),
+		Err:   nil,
+	}
+	r.awsClient = m
+	r.searchRoles = true
+
+	return r, m
+}
+
+func TestRoleCache_SuccessfulLookup(t *testing.T) {
+	r, mock := getMockedRoleCache()
+
+	mock.Pages = append(mock.Pages, &iam.ListRolesOutput{Roles: []*iam.Role{
+		{RoleId: aws.String("someid1"), Arn: aws.String("somearn1")},
+	}})
+
+	lookupARN1, exists1 := r.CheckRoleID("someid1")
+	if !exists1 {
+		t.Fatal("ARN lookup 1 should have found an ARN")
+	}
+	if lookupARN1 != "somearn1" {
+		t.Fatalf("ARN lookup 1 expected %s, got %s", "somearn1", lookupARN1)
+	}
+	if mock.Called != 1 {
+		t.Fatal("IAM Mock called counter incorrect")
+	}
+
+	_, exists2 := r.CheckRoleID("someid2")
+	if exists2 {
+		t.Fatal("ARN lookup 2 should have not found an ARN")
+	}
+	if mock.Called != 1 {
+		t.Fatalf("IAM Mock called erronously, counter should be %d but got %d", 1, mock.Called)
+	}
+}
+
+func TestRoleCache_AccessDenied(t *testing.T) {
+	r, mock := getMockedRoleCache()
+
+	mock.Err = awserr.New("AccessDenied", "access denied", errors.New("some access denied error"))
+	_, exists := r.CheckRoleID("someid1")
+	if exists {
+		t.Fatal("ARN lookup should have not found an ARN")
+	}
+	if mock.Called != 1 {
+		t.Fatal("Mock lookup was not called")
+	}
+	if r.searchRoles {
+		t.Fatal("Role searching should have been permanently disabled")
+	}
+}
+
+func TestRoleCache_NoCredentialProviders(t *testing.T) {
+	r, mock := getMockedRoleCache()
+
+	mock.Err = awserr.New("NoCredentialProviders", "no creds", errors.New("no creds"))
+	_, exists := r.CheckRoleID("someid1")
+	if exists {
+		t.Fatal("ARN lookup should have not found an ARN")
+	}
+	if mock.Called != 1 {
+		t.Fatal("Mock lookup was not called")
+	}
+	if r.searchRoles {
+		t.Fatal("Role searching should have been permanently disabled")
+	}
+}
+
+func TestRoleCache_TransientError(t *testing.T) {
+	r, mock := getMockedRoleCache()
+
+	mock.Err = awserr.New("TransientError", "random error", errors.New("random error"))
+	_, exists := r.CheckRoleID("someid1")
+	if exists {
+		t.Fatal("ARN lookup should have not found an ARN")
+	}
+	if mock.Called != 1 {
+		t.Fatal("Mock lookup was not called")
+	}
+	if !r.searchRoles {
+		t.Fatal("Role searching should not have been permanently disabled")
+	}
+}
+
+func TestRoleCache_NonAWSError(t *testing.T) {
+	r, mock := getMockedRoleCache()
+
+	mock.Err = errors.New("non aws error")
+	_, exists := r.CheckRoleID("someid1")
+	if exists {
+		t.Fatal("ARN lookup should have not found an ARN")
+	}
+	if mock.Called != 1 {
+		t.Fatal("Mock lookup was not called")
+	}
+	if r.searchRoles {
+		t.Fatal("Role searching should have been permanently disabled")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: When creating EKS nodegroups where the node's IAM role contains a path, the nodes fail to join the cluster. This adds the ability to look up a role's full ARN including the path and return that when verifying a token.

The reason this is needed is because the assume-role ARN that is returned by `sts.get-caller-idendentity` does not include the IAM role's path.

I've added a "role cache" which calles `iam.list-roles` and stores a mapping between the roles unique role ID and the full ARN, as the `UserID` returned by `sts.get-caller-identity` contains the roles unique ID therefore looking up the existing role's correct ARN is possible.

This does require the clusters IAM role to have the `iam:ListRoles` action. If the role cache gets an error when calling list roles and its not a transient error, it'll disable all future lookups and the functionality will revert to the original behaviour. I figured it would be better to make this more an opt in rather than a requirement as else it might just break nodes joining a cluster whenever its released.

**Which issue(s) this PR fixes**:
Fixes #268
Fixes #153 

