### PR TITLE
Removed emeritus reviewers from SECURITY_CONTACTS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ approvers:
 - nckturner
 - micahhausler
 - wongma7
-- jaypipes
 - jyotimahapatra
 
 reviewers:
@@ -10,10 +9,10 @@ reviewers:
 - micahhausler
 - justinsb
 - wongma7
-- jaypipes
 - jyotimahapatra
 
 emeritus_approvers:
 - christopherhein
 - mattmoyer
 - mattlandis
+- jaypipes

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,8 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-mattmoyer
 nckturner
-mattlandis
-christopherhein
 micahhausler
+wongma7
+jyotimahapatra


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleanup of emeritus reviewers. 


cc @jaypipes @jyotimahapatra @wongma7 

