### PR TITLE
Fix federated user ID parsing

### DIFF
--- a/pkg/arn/arn_test.go
+++ b/pkg/arn/arn_test.go
@@ -23,7 +23,7 @@ var arnTests = []struct {
 
 func TestUserARN(t *testing.T) {
 	for _, tc := range arnTests {
-		actual, err := Canonicalize(tc.arn)
+		_, actual, err := Canonicalize(tc.arn)
 		if err != nil && tc.err == nil || err == nil && tc.err != nil {
 			t.Errorf("Canoncialize(%s) expected err: %v, actual err: %v", tc.arn, tc.err, err)
 			continue

--- a/pkg/mapper/crd/controller/controller.go
+++ b/pkg/mapper/crd/controller/controller.go
@@ -207,7 +207,7 @@ func (c *Controller) syncHandler(key string) (err error) {
 	if iamIdentityMapping.Spec.ARN != "" {
 		iamIdentityMappingCopy := iamIdentityMapping.DeepCopy()
 
-		canonicalizedARN, err := arn.Canonicalize(strings.ToLower(iamIdentityMapping.Spec.ARN))
+		_, canonicalizedARN, err := arn.Canonicalize(strings.ToLower(iamIdentityMapping.Spec.ARN))
 		if err != nil {
 			return err
 		}

--- a/pkg/mapper/dynamicfile/dynamicfile.go
+++ b/pkg/mapper/dynamicfile/dynamicfile.go
@@ -63,14 +63,14 @@ func (ms *DynamicFileMapStore) saveMap(
 	ms.awsAccounts = make(map[string]interface{})
 
 	for _, user := range userMappings {
-		key, _ := arn.Canonicalize(strings.ToLower(user.UserARN))
+		_, key, _ := arn.Canonicalize(strings.ToLower(user.UserARN))
 		if ms.userIDStrict {
 			key = user.UserId
 		}
 		ms.users[key] = user
 	}
 	for _, role := range roleMappings {
-		key, _ := arn.Canonicalize(strings.ToLower(role.RoleARN))
+		_, key, _ := arn.Canonicalize(strings.ToLower(role.RoleARN))
 		if ms.userIDStrict {
 			key = role.UserId
 		}

--- a/pkg/mapper/file/mapper.go
+++ b/pkg/mapper/file/mapper.go
@@ -2,8 +2,9 @@ package file
 
 import (
 	"fmt"
-	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 	"strings"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
@@ -32,7 +33,7 @@ func NewFileMapper(cfg config.Config) (*FileMapper, error) {
 			return nil, err
 		}
 		if m.RoleARN != "" {
-			canonicalizedARN, err := arn.Canonicalize(m.RoleARN)
+			_, canonicalizedARN, err := arn.Canonicalize(m.RoleARN)
 			if err != nil {
 				return nil, err
 			}
@@ -47,7 +48,7 @@ func NewFileMapper(cfg config.Config) (*FileMapper, error) {
 		}
 		var key string
 		if m.UserARN != "" {
-			canonicalizedARN, err := arn.Canonicalize(strings.ToLower(m.UserARN))
+			_, canonicalizedARN, err := arn.Canonicalize(strings.ToLower(m.UserARN))
 			if err != nil {
 				return nil, fmt.Errorf("error canonicalizing ARN: %v", err)
 			}


### PR DESCRIPTION
* refactor the parsing logic to make it easier

**What this PR does / why we need it**:
This PR changes the way the federated user ID is treated.  Instead of splitting at a colon like we do for assumed-roles, we take the whole value.  This is because if we split at the colon, the user ID is just the account number and can't be differentiated from the root user.  

