### PR TITLE
Cherry-pick: Update go to 1.21.4 (#648)

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,28 @@
+name: "Dependency Review"
+on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v3
+        with:
+          vulnerability-check: false
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.21.4
+          go-version-file: go.mod

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-02-22-1677092456.2
-ARG golang_image=public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc
+ARG golang_image=public.ecr.aws/docker/library/golang:1.21.4
 
 FROM --platform=$BUILDPLATFORM $golang_image AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-iam-authenticator


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/648

**What this PR does / why we need it**:
Update go to v1.21.4


