### PR TITLE
Cherry-pick: Check ARN for user ID strict check (#660)

### DIFF
--- a/pkg/config/mapper.go
+++ b/pkg/config/mapper.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"strings"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
+)
+
+// IdentityMapping converts the RoleMapping into a generic IdentityMapping object
+func (m *RoleMapping) IdentityMapping(identity *token.Identity) *IdentityMapping {
+	return &IdentityMapping{
+		IdentityARN: strings.ToLower(identity.CanonicalARN),
+		Username:    m.Username,
+		Groups:      m.Groups,
+	}
+}
+
+// IdentityMapping converts the UserMapping into a generic IdentityMapping object
+func (m *UserMapping) IdentityMapping(identity *token.Identity) *IdentityMapping {
+	return &IdentityMapping{
+		IdentityARN: strings.ToLower(identity.CanonicalARN),
+		Username:    m.Username,
+		Groups:      m.Groups,
+	}
+}

--- a/pkg/errutil/errors.go
+++ b/pkg/errutil/errors.go
@@ -1,0 +1,9 @@
+package errutil
+
+import (
+	"errors"
+)
+
+var ErrNotMapped = errors.New("Identity is not mapped")
+
+var ErrIDAndARNMismatch = errors.New("ARN does not match User ID")

--- a/pkg/mapper/configmap/mapper.go
+++ b/pkg/mapper/configmap/mapper.go
@@ -1,8 +1,10 @@
 package configmap
 
 import (
-	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 	"strings"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
@@ -53,7 +55,7 @@ func (m *ConfigMapMapper) Map(identity *token.Identity) (*config.IdentityMapping
 		}, nil
 	}
 
-	return nil, mapper.ErrNotMapped
+	return nil, errutil.ErrNotMapped
 }
 
 func (m *ConfigMapMapper) IsAccountAllowed(accountID string) bool {

--- a/pkg/mapper/crd/mapper.go
+++ b/pkg/mapper/crd/mapper.go
@@ -2,9 +2,11 @@ package crd
 
 import (
 	"fmt"
-	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -114,7 +116,7 @@ func (m *CRDMapper) Map(identity *token.Identity) (*config.IdentityMapping, erro
 		}
 	}
 
-	return nil, mapper.ErrNotMapped
+	return nil, errutil.ErrNotMapped
 }
 
 func (m *CRDMapper) IsAccountAllowed(accountID string) bool {

--- a/pkg/mapper/dynamicfile/dynamicfile.go
+++ b/pkg/mapper/dynamicfile/dynamicfile.go
@@ -2,7 +2,6 @@ package dynamicfile
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -10,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
 )
 
 type DynamicFileMapStore struct {
@@ -81,27 +81,21 @@ func (ms *DynamicFileMapStore) saveMap(
 	}
 }
 
-// UserNotFound is the error returned when the user is not found in the config map.
-var UserNotFound = errors.New("User not found in dynamic file")
-
-// RoleNotFound is the error returned when the role is not found in the config map.
-var RoleNotFound = errors.New("Role not found in dynamic file")
-
-func (ms *DynamicFileMapStore) UserMapping(arn string) (config.UserMapping, error) {
+func (ms *DynamicFileMapStore) UserMapping(key string) (config.UserMapping, error) {
 	ms.mutex.RLock()
 	defer ms.mutex.RUnlock()
-	if user, ok := ms.users[arn]; !ok {
-		return config.UserMapping{}, UserNotFound
+	if user, ok := ms.users[key]; !ok {
+		return config.UserMapping{}, errutil.ErrNotMapped
 	} else {
 		return user, nil
 	}
 }
 
-func (ms *DynamicFileMapStore) RoleMapping(arn string) (config.RoleMapping, error) {
+func (ms *DynamicFileMapStore) RoleMapping(key string) (config.RoleMapping, error) {
 	ms.mutex.RLock()
 	defer ms.mutex.RUnlock()
-	if role, ok := ms.roles[arn]; !ok {
-		return config.RoleMapping{}, RoleNotFound
+	if role, ok := ms.roles[key]; !ok {
+		return config.RoleMapping{}, errutil.ErrNotMapped
 	} else {
 		return role, nil
 	}

--- a/pkg/mapper/file/mapper.go
+++ b/pkg/mapper/file/mapper.go
@@ -6,6 +6,7 @@ import (
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 )
@@ -86,8 +87,7 @@ func (m *FileMapper) Map(identity *token.Identity) (*config.IdentityMapping, err
 			Groups:      userMapping.Groups,
 		}, nil
 	}
-
-	return nil, mapper.ErrNotMapped
+	return nil, errutil.ErrNotMapped
 }
 
 func (m *FileMapper) IsAccountAllowed(accountID string) bool {

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -1,8 +1,8 @@
 package mapper
 
 import (
-	"errors"
 	"fmt"
+
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
 	"github.com/sirupsen/logrus"
@@ -33,8 +33,6 @@ var (
 	}
 	BackendModeChoices = []string{ModeMountedFile, ModeEKSConfigMap, ModeCRD, ModeDynamicFile}
 )
-
-var ErrNotMapped = errors.New("ARN is not mapped")
 
 type Mapper interface {
 	Name() string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/ec2provider"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/fileutil"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/configmap"
@@ -417,7 +418,7 @@ func (h *handler) doMapping(identity *token.Identity) (string, []string, error) 
 			}
 			return username, groups, nil
 		} else {
-			if err != mapper.ErrNotMapped {
+			if err != errutil.ErrNotMapped {
 				errs = append(errs, fmt.Errorf("mapper %s Map error: %v", m.Name(), err))
 			}
 
@@ -430,7 +431,7 @@ func (h *handler) doMapping(identity *token.Identity) (string, []string, error) 
 	if len(errs) > 0 {
 		return "", nil, utilerrors.NewAggregate(errs)
 	}
-	return "", nil, mapper.ErrNotMapped
+	return "", nil, errutil.ErrNotMapped
 }
 
 func (h *handler) renderTemplates(mapping config.IdentityMapping, identity *token.Identity) (string, []string, error) {


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/660

**What this PR does / why we need it**:

Check ARN when mapping based on User ID. This is necessary because IAM User names/ARNs can change, and without this check, it would be difficult to determine which IAM users currently have access to a cluster.

