### PR TITLE
Fix role ARN comparison for user ID strict check

### DIFF
--- a/pkg/arn/arn_test.go
+++ b/pkg/arn/arn_test.go
@@ -33,3 +33,28 @@ func TestUserARN(t *testing.T) {
 		}
 	}
 }
+
+var arnStripTests = []struct {
+	arn      string // input arn
+	expected string // canonacalized arn
+	err      error  // expected error value
+}{
+	{"NOT AN ARN", "", fmt.Errorf("Not an arn")},
+	{"arn:aws:iam::123456789012:role/Org/Team/Admin", "arn:aws:iam::123456789012:role/Admin", nil},
+	{"arn:aws:iam::123456789012:role/Admin", "arn:aws:iam::123456789012:role/Admin", nil},
+	{"arn:aws:iam::123456789012:user/Alice", "arn:aws:iam::123456789012:user/Alice", nil},
+	{"arn:aws:sts::123456789012:federated-user/Bob", "arn:aws:sts::123456789012:federated-user/Bob", nil},
+}
+
+func TestStripPath(t *testing.T) {
+	for _, tc := range arnStripTests {
+		actual, err := StripPath(tc.arn)
+		if err != nil && tc.err == nil || err == nil && tc.err != nil {
+			t.Errorf("stripPath(%s) expected err: %v, actual err: %v", tc.arn, tc.err, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("stripPath(%s) expected: %s, actual: %s", tc.arn, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/mapper/dynamicfile/mapper.go
+++ b/pkg/mapper/dynamicfile/mapper.go
@@ -3,6 +3,7 @@ package dynamicfile
 import (
 	"strings"
 
+	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/fileutil"
@@ -66,7 +67,8 @@ func (m *DynamicFileMapper) match(token *token.Identity, mappedARN, mappedUserID
 		// If ARN is provided, ARN must be validated along with UserID.  This avoids having to
 		// support IAM user name/ARN changes. Without preventing this the mapping would look
 		// invalid but still work and auditing would be difficult/impossible.
-		if mappedARN != "" && token.ARN != mappedARN {
+		strippedArn, _ := arn.StripPath(mappedARN)
+		if strippedArn != "" && token.CanonicalARN != strings.ToLower(strippedArn) {
 			return errutil.ErrIDAndARNMismatch
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes UserID strict ARN comparison for roles by comparing mapped arn against the identity's canonical arn (role representation) rather than the identity's arn (assume role format). Additionally strips the role path off of the dynamic file role mapping for this check since assumed roles don't have path info.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

