### PR TITLE
add support for e2e latency for dynamic mode and adoption rate metrics

### DIFF
--- a/pkg/fileutil/util.go
+++ b/pkg/fileutil/util.go
@@ -1,6 +1,7 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -109,16 +110,20 @@ func StartLoadDynamicFile(filename string, callBack FileChangeCallBack, stopCh <
 func CalculateTimeDeltaFromUnixInSeconds(from, to string) (float64, error) {
 	parsedFrom, err := strconv.ParseInt(from, 10, 64)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to parse 'from' string: %v", err)
 	}
 
 	parsedTo, err := strconv.ParseInt(to, 10, 64)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to parse 'to' string: %v", err)
 	}
 
 	timeFrom := time.Unix(parsedFrom, 0).UTC()
 	timeTo := time.Unix(parsedTo, 0).UTC()
+
+	if timeFrom.After(timeTo) {
+		return 0, fmt.Errorf("start timestamp is after end timestamp")
+	}
 
 	return timeTo.Sub(timeFrom).Seconds(), nil
 }

--- a/pkg/fileutil/util.go
+++ b/pkg/fileutil/util.go
@@ -2,6 +2,7 @@ package fileutil
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -103,4 +104,21 @@ func StartLoadDynamicFile(filename string, callBack FileChangeCallBack, stopCh <
 			}
 		}
 	}, time.Second, stopCh)
+}
+
+func CalculateTimeDeltaFromUnixInSeconds(from, to string) (float64, error) {
+	parsedFrom, err := strconv.ParseInt(from, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	parsedTo, err := strconv.ParseInt(to, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	timeFrom := time.Unix(parsedFrom, 0).UTC()
+	timeTo := time.Unix(parsedTo, 0).UTC()
+
+	return timeTo.Sub(timeFrom).Seconds(), nil
 }

--- a/pkg/fileutil/util.go
+++ b/pkg/fileutil/util.go
@@ -107,23 +107,17 @@ func StartLoadDynamicFile(filename string, callBack FileChangeCallBack, stopCh <
 	}, time.Second, stopCh)
 }
 
-func CalculateTimeDeltaFromUnixInSeconds(from, to string) (float64, error) {
-	parsedFrom, err := strconv.ParseInt(from, 10, 64)
+func CalculateTimeDeltaFromUnixInSeconds(from string) (int64, error) {
+	startTime, err := strconv.ParseInt(from, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse 'from' string: %v", err)
+		return 0, fmt.Errorf("failed to parse 'startTime' string: %v", err)
 	}
 
-	parsedTo, err := strconv.ParseInt(to, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse 'to' string: %v", err)
-	}
+	endTime := time.Now().Unix()
 
-	timeFrom := time.Unix(parsedFrom, 0).UTC()
-	timeTo := time.Unix(parsedTo, 0).UTC()
-
-	if timeFrom.After(timeTo) {
+	if startTime > endTime {
 		return 0, fmt.Errorf("start timestamp is after end timestamp")
 	}
 
-	return timeTo.Sub(timeFrom).Seconds(), nil
+	return endTime - startTime, nil
 }

--- a/pkg/fileutil/util_test.go
+++ b/pkg/fileutil/util_test.go
@@ -122,3 +122,34 @@ func TestDeleteDynamicFile(t *testing.T) {
 	}
 	testA.mutex.Unlock()
 }
+
+func TestCalculateTimeDeltaFromUnixInSeconds(t *testing.T) {
+	type args struct {
+		from string
+		to   string
+	}
+	cases := []struct {
+		input args
+		want  float64
+	}{
+		{
+			args{"1706648530", "1706648539"},
+			9.0,
+		},
+		{
+			args{"1706648520", "1706648539"},
+			19.0,
+		},
+	}
+
+	for _, c := range cases {
+		out, err := CalculateTimeDeltaFromUnixInSeconds(c.input.from, c.input.to)
+		if err != nil {
+			t.Errorf("error is not expected")
+		}
+
+		if out != c.want {
+			t.Errorf("unexpected result: got %v but expected %v", out, c.want)
+		}
+	}
+}

--- a/pkg/fileutil/util_test.go
+++ b/pkg/fileutil/util_test.go
@@ -1,6 +1,7 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -129,23 +130,44 @@ func TestCalculateTimeDeltaFromUnixInSeconds(t *testing.T) {
 		to   string
 	}
 	cases := []struct {
-		input args
-		want  float64
+		input  args
+		want   float64
+		errexp bool
 	}{
 		{
 			args{"1706648530", "1706648539"},
 			9.0,
+			false,
 		},
 		{
 			args{"1706648520", "1706648539"},
 			19.0,
+			false,
+		},
+		{
+			args{"1906648520", "1806648539"},
+			0,
+			true,
+		},
+		{
+			args{"foo", "1806648539"},
+			0,
+			true,
+		},
+		{
+			args{"1706648520", "bar"},
+			0,
+			true,
 		},
 	}
 
 	for _, c := range cases {
+		fmt.Println(c.input.from, c.input.to)
 		out, err := CalculateTimeDeltaFromUnixInSeconds(c.input.from, c.input.to)
-		if err != nil {
-			t.Errorf("error is not expected")
+		if !c.errexp && err != nil {
+			t.Errorf("Did not expect error but got err: %v", err)
+		} else if c.errexp && err == nil {
+			t.Error("Expected error but got nil")
 		}
 
 		if out != c.want {

--- a/pkg/fileutil/util_test.go
+++ b/pkg/fileutil/util_test.go
@@ -1,8 +1,8 @@
 package fileutil
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -126,52 +126,54 @@ func TestDeleteDynamicFile(t *testing.T) {
 
 func TestCalculateTimeDeltaFromUnixInSeconds(t *testing.T) {
 	type args struct {
-		from string
-		to   string
+		startTime string
 	}
 	cases := []struct {
 		input  args
-		want   float64
 		errexp bool
+		sleep  bool
 	}{
 		{
-			args{"1706648530", "1706648539"},
-			9.0,
+			args{"1706648530"},
+			false,
 			false,
 		},
 		{
-			args{"1706648520", "1706648539"},
-			19.0,
+			args{"1706648520"},
+			false,
 			false,
 		},
 		{
-			args{"1906648520", "1806648539"},
-			0,
+			args{"foo"},
 			true,
+			false,
 		},
 		{
-			args{"foo", "1806648539"},
-			0,
+			args{"2706648520"},
 			true,
+			false,
 		},
 		{
-			args{"1706648520", "bar"},
-			0,
+			args{strconv.FormatInt(time.Now().Unix(), 10)},
+			false,
 			true,
 		},
 	}
 
 	for _, c := range cases {
-		fmt.Println(c.input.from, c.input.to)
-		out, err := CalculateTimeDeltaFromUnixInSeconds(c.input.from, c.input.to)
+		if c.sleep {
+			time.Sleep(1 * time.Second)
+		}
+
+		out, err := CalculateTimeDeltaFromUnixInSeconds(c.input.startTime)
 		if !c.errexp && err != nil {
 			t.Errorf("Did not expect error but got err: %v", err)
 		} else if c.errexp && err == nil {
 			t.Error("Expected error but got nil")
 		}
 
-		if out != c.want {
-			t.Errorf("unexpected result: got %v but expected %v", out, c.want)
+		if !c.errexp && out < 1 {
+			t.Errorf("Returned an invalid value: %d", out)
 		}
 	}
 }

--- a/pkg/mapper/dynamicfile/dynamicfile.go
+++ b/pkg/mapper/dynamicfile/dynamicfile.go
@@ -196,15 +196,16 @@ func (ms *DynamicFileMapStore) CallBackForFileLoad(dynamicContent []byte) error 
 	} else {
 		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(dynamicFileData.LastUpdatedDateTime, strconv.FormatInt(time.Now().Unix(), 10))
 		if err != nil {
-			return fmt.Errorf("error parsing latency for dynamic file: %v", err)
+			logrus.Errorf("error parsing latency for dynamic file: %v", err)
+		} else {
+			metrics.Get().E2ELatency.WithLabelValues("dynamic_file").Observe(latency)
+			logrus.WithFields(logrus.Fields{
+				"ClusterId": dynamicFileData.ClusterID,
+				"Version":   dynamicFileData.Version,
+				"Type":      "dynamic_file",
+				"Latency":   latency,
+			}).Infof("logging latency metric")
 		}
-		metrics.Get().E2ELatency.WithLabelValues("dynamic_file").Observe(latency)
-		logrus.WithFields(logrus.Fields{
-			"ClusterId": dynamicFileData.ClusterID,
-			"Version":   dynamicFileData.Version,
-			"Type":      "dynamic_file",
-			"Latency":   latency,
-		}).Infof("logging latency metric")
 	}
 
 	return nil

--- a/pkg/mapper/dynamicfile/dynamicfile.go
+++ b/pkg/mapper/dynamicfile/dynamicfile.go
@@ -3,10 +3,8 @@ package dynamicfile
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
@@ -181,11 +179,11 @@ func (ms *DynamicFileMapStore) CallBackForFileLoad(dynamicContent []byte) error 
 	// so a workaround is to skip the first time the metric is calculated, and only emit metris after
 	// as we know any subsequent calculations are from a valid change upstream
 	if ms.dynamicFileInitDone {
-		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(dynamicFileData.LastUpdatedDateTime, strconv.FormatInt(time.Now().Unix(), 10))
+		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(dynamicFileData.LastUpdatedDateTime)
 		if err != nil {
 			logrus.Errorf("error parsing latency for dynamic file: %v", err)
 		} else {
-			metrics.Get().E2ELatency.WithLabelValues("dynamic_file").Observe(latency)
+			metrics.Get().E2ELatency.WithLabelValues("dynamic_file").Observe(float64(latency))
 			logrus.WithFields(logrus.Fields{
 				"Version": dynamicFileData.Version,
 				"Type":    "dynamic_file",

--- a/pkg/mapper/dynamicfile/dynamicfile_test.go
+++ b/pkg/mapper/dynamicfile/dynamicfile_test.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/errutil"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/fileutil"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 )
 
@@ -17,6 +19,11 @@ var (
 	testUser = config.UserMapping{UserARN: "arn:aws:iam::012345678912:user/matt", Username: "matlan", Groups: []string{"system:master", "dev"}}
 	testRole = config.RoleMapping{RoleARN: "arn:aws:iam::012345678912:role/computer", Username: "computer", Groups: []string{"system:nodes"}}
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitMetrics(prometheus.NewRegistry())
+	m.Run()
+}
 
 func makeStore(users map[string]config.UserMapping, roles map[string]config.RoleMapping, filename string, userIDStrict bool) DynamicFileMapStore {
 	ms := DynamicFileMapStore{
@@ -96,6 +103,10 @@ func TestAWSAccount(t *testing.T) {
 
 var origFileContent = `
 {
+  "ApiVersion": "1",
+  "Version": "1",
+  "LastUpdatedDateTime": "12345678",
+  "ClusterId": "000000000098",
   "mapRoles": [
     {
       "rolearn": "arn:aws:iam::000000000098:role/KubernetesAdmin",
@@ -133,6 +144,10 @@ var origFileContent = `
 
 var updatedFileContent = `
 {
+  "ApiVersion": "1",
+  "Version": "1",
+  "LastUpdatedDateTime": "12345678",
+  "ClusterId": "000000000098",
   "mapRoles": [
     {
       "rolearn": "arn:aws:iam::000000000098:role/KubernetesAdmin",

--- a/pkg/mapper/dynamicfile/dynamicfile_test.go
+++ b/pkg/mapper/dynamicfile/dynamicfile_test.go
@@ -103,7 +103,6 @@ func TestAWSAccount(t *testing.T) {
 
 var origFileContent = `
 {
-  "ApiVersion": "1",
   "Version": "1",
   "LastUpdatedDateTime": "12345678",
   "ClusterId": "000000000098",
@@ -144,7 +143,6 @@ var origFileContent = `
 
 var updatedFileContent = `
 {
-  "ApiVersion": "1",
   "Version": "1",
   "LastUpdatedDateTime": "12345678",
   "ClusterId": "000000000098",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -42,6 +42,7 @@ type Metrics struct {
 	StsResponses                 *prometheus.CounterVec
 	DynamicFileFailures          prometheus.Counter
 	StsThrottling                prometheus.Counter
+	E2ELatency                   *prometheus.HistogramVec
 }
 
 func createMetrics(reg prometheus.Registerer) Metrics {
@@ -97,6 +98,15 @@ func createMetrics(reg prometheus.Registerer) Metrics {
 				Name:      "ec2_describe_instances_calls_total",
 				Help:      "Number of EC2 describe instances calls.",
 			},
+		),
+		E2ELatency: factory.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:      "dynamic_e2e_latency_seconds",
+				Namespace: Namespace,
+				Help:      "End to end latency in seconds partitioned by type.",
+				Buckets:   []float64{1, 3, 5, 10, 15, 20, 30, 60},
+			},
+			[]string{"type"},
 		),
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,8 @@ type Metrics struct {
 	DynamicFileFailures          prometheus.Counter
 	StsThrottling                prometheus.Counter
 	E2ELatency                   *prometheus.HistogramVec
+	DynamicFileEnabled           prometheus.Gauge
+	DynamicFileOnly              prometheus.Gauge
 }
 
 func createMetrics(reg prometheus.Registerer) Metrics {
@@ -107,6 +109,20 @@ func createMetrics(reg prometheus.Registerer) Metrics {
 				Buckets:   []float64{1, 3, 5, 10, 15, 20, 30, 60},
 			},
 			[]string{"type"},
+		),
+		DynamicFileEnabled: factory.NewGauge(
+			prometheus.GaugeOpts{
+				Name:      "dynamic_file_enabled",
+				Namespace: Namespace,
+				Help:      "Dynamic file in backend mode is enabled",
+			},
+		),
+		DynamicFileOnly: factory.NewGauge(
+			prometheus.GaugeOpts{
+				Name:      "dynamic_file_only",
+				Namespace: Namespace,
+				Help:      "Only dynamic file in backend mode is enabled",
+			},
 		),
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,14 +71,14 @@ var (
 // server state (internal)
 type handler struct {
 	http.ServeMux
-	mutex                      sync.RWMutex
-	verifier                   token.Verifier
-	ec2Provider                ec2provider.EC2Provider
-	clusterID                  string
-	backendMapper              BackendMapper
-	skipFirstTimeLatencyMetric bool
-	scrubbedAccounts           []string
-	cfg                        config.Config
+	mutex                     sync.RWMutex
+	verifier                  token.Verifier
+	ec2Provider               ec2provider.EC2Provider
+	clusterID                 string
+	backendMapper             BackendMapper
+	backendModeConfigInitDone bool
+	scrubbedAccounts          []string
+	cfg                       config.Config
 }
 
 // New authentication webhook server.
@@ -207,13 +207,13 @@ func (c *Server) getHandler(backendMapper BackendMapper, ec2DescribeQps int, ec2
 	}
 
 	h := &handler{
-		verifier:                   token.NewVerifier(c.ClusterID, c.PartitionID, instanceRegion),
-		ec2Provider:                ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
-		clusterID:                  c.ClusterID,
-		backendMapper:              backendMapper,
-		scrubbedAccounts:           c.Config.ScrubbedAWSAccounts,
-		cfg:                        c.Config,
-		skipFirstTimeLatencyMetric: true,
+		verifier:                  token.NewVerifier(c.ClusterID, c.PartitionID, instanceRegion),
+		ec2Provider:               ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
+		clusterID:                 c.ClusterID,
+		backendMapper:             backendMapper,
+		scrubbedAccounts:          c.Config.ScrubbedAWSAccounts,
+		cfg:                       c.Config,
+		backendModeConfigInitDone: false,
 	}
 
 	h.HandleFunc("/authenticate", h.authenticateEndpoint)
@@ -517,26 +517,24 @@ func (h *handler) CallBackForFileLoad(dynamicContent []byte) error {
 		logrus.Infof("BackendMode dynamic file got changed, but same with current mode, skip rebuild mapper")
 	}
 
-	// when instance or container restarts, the dynamic file is (re)loaded and the latency metric is calculated
+	// when instance or container restarts, the backendend mode config is (re)loaded and the latency metric is calculated
 	// regardless if there was a change upstream, and thus can emit an incorrect latency value
 	// so a workaround is to skip the first time the metric is calculated, and only emit metris after
 	// as we know any subsequent calculations are from a valid change upstream
-	if h.skipFirstTimeLatencyMetric {
-		h.skipFirstTimeLatencyMetric = false
-	} else {
+	if h.backendModeConfigInitDone {
 		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(backendModes.LastUpdatedDateTime, strconv.FormatInt(time.Now().Unix(), 10))
 		if err != nil {
 			logrus.Errorf("error parsing latency for dynamic backend mode file: %v", err)
 		} else {
 			metrics.Get().E2ELatency.WithLabelValues("dynamic_backend_mode").Observe(latency)
 			logrus.WithFields(logrus.Fields{
-				"ClusterId": backendModes.ClusterID,
-				"Version":   backendModes.Version,
-				"Type":      "dynamic_backend_mode",
-				"Latency":   latency,
+				"Version": backendModes.Version,
+				"Type":    "dynamic_backend_mode",
+				"Latency": latency,
 			}).Infof("logging latency metric")
 		}
 	}
+	h.backendModeConfigInitDone = true
 
 	if h.backendMapper.currentModes == mapper.ModeDynamicFile {
 		metrics.Get().DynamicFileOnly.Set(1)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -70,13 +71,14 @@ var (
 // server state (internal)
 type handler struct {
 	http.ServeMux
-	mutex            sync.RWMutex
-	verifier         token.Verifier
-	ec2Provider      ec2provider.EC2Provider
-	clusterID        string
-	backendMapper    BackendMapper
-	scrubbedAccounts []string
-	cfg              config.Config
+	mutex               sync.RWMutex
+	verifier            token.Verifier
+	ec2Provider         ec2provider.EC2Provider
+	clusterID           string
+	backendMapper       BackendMapper
+	skipFirstTimeMetric bool
+	scrubbedAccounts    []string
+	cfg                 config.Config
 }
 
 // New authentication webhook server.
@@ -205,12 +207,13 @@ func (c *Server) getHandler(backendMapper BackendMapper, ec2DescribeQps int, ec2
 	}
 
 	h := &handler{
-		verifier:         token.NewVerifier(c.ClusterID, c.PartitionID, instanceRegion),
-		ec2Provider:      ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
-		clusterID:        c.ClusterID,
-		backendMapper:    backendMapper,
-		scrubbedAccounts: c.Config.ScrubbedAWSAccounts,
-		cfg:              c.Config,
+		verifier:            token.NewVerifier(c.ClusterID, c.PartitionID, instanceRegion),
+		ec2Provider:         ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
+		clusterID:           c.ClusterID,
+		backendMapper:       backendMapper,
+		scrubbedAccounts:    c.Config.ScrubbedAWSAccounts,
+		cfg:                 c.Config,
+		skipFirstTimeMetric: true,
 	}
 
 	h.HandleFunc("/authenticate", h.authenticateEndpoint)
@@ -513,6 +516,27 @@ func (h *handler) CallBackForFileLoad(dynamicContent []byte) error {
 	} else {
 		logrus.Infof("BackendMode dynamic file got changed, but same with current mode, skip rebuild mapper")
 	}
+
+	// when instance or container restarts, the dynamic file is (re)loaded and the latency metric is calculated
+	// regardless if there was a change upstream, and thus can emit an incorrect latency value
+	// so a workaround is to skip the first time the metric is calculated, and only emit metris after
+	// as we know any subsequent calculations are from a valid change upstream
+	if h.skipFirstTimeMetric {
+		h.skipFirstTimeMetric = false
+	} else {
+		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(backendModes.LastUpdatedDateTime, strconv.FormatInt(time.Now().Unix(), 10))
+		if err != nil {
+			return fmt.Errorf("error parsing latency for dynamic backend mode file: %v", err)
+		}
+		metrics.Get().E2ELatency.WithLabelValues("dynamic_backend_mode").Observe(latency)
+		logrus.WithFields(logrus.Fields{
+			"ClusterId": backendModes.ClusterID,
+			"Version":   backendModes.Version,
+			"Type":      "dynamic_backend_mode",
+			"Latency":   latency,
+		}).Infof("logging latency metric")
+	}
+
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -522,11 +521,11 @@ func (h *handler) CallBackForFileLoad(dynamicContent []byte) error {
 	// so a workaround is to skip the first time the metric is calculated, and only emit metris after
 	// as we know any subsequent calculations are from a valid change upstream
 	if h.backendModeConfigInitDone {
-		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(backendModes.LastUpdatedDateTime, strconv.FormatInt(time.Now().Unix(), 10))
+		latency, err := fileutil.CalculateTimeDeltaFromUnixInSeconds(backendModes.LastUpdatedDateTime)
 		if err != nil {
 			logrus.Errorf("error parsing latency for dynamic backend mode file: %v", err)
 		} else {
-			metrics.Get().E2ELatency.WithLabelValues("dynamic_backend_mode").Observe(latency)
+			metrics.Get().E2ELatency.WithLabelValues("dynamic_backend_mode").Observe(float64(latency))
 			logrus.WithFields(logrus.Fields{
 				"Version": backendModes.Version,
 				"Type":    "dynamic_backend_mode",

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/dynamicfile"
 )
 
 // Server for the authentication webhook.
@@ -41,5 +42,6 @@ type BackendMapper struct {
 
 // AccessConfig represents the configuration format for cluster access config via backend mode.
 type BackendModeConfig struct {
+	dynamicfile.Meta
 	BackendMode string `json:"backendMode"`
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -22,7 +22,6 @@ import (
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
-	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper/dynamicfile"
 )
 
 // Server for the authentication webhook.
@@ -42,6 +41,9 @@ type BackendMapper struct {
 
 // AccessConfig represents the configuration format for cluster access config via backend mode.
 type BackendModeConfig struct {
-	dynamicfile.Meta
+	// Time that the object takes from update time to load time
+	LastUpdatedDateTime string `json:"LastUpdatedDateTime"`
+	// Version is the version number of the update
+	Version     string `json:"Version"`
 	BackendMode string `json:"backendMode"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds logic to support e2e latency for dynamic mode and dynamic backend mode files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

