### PR TITLE
chore: Update CI action versions, remove `push` trigger

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,5 +1,6 @@
 # Github Action to create a release with goreleaser
 name: Create Release
+
 on:
   workflow_dispatch:
   push:
@@ -11,18 +12,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ssh-key: "${{ secrets.RELEASE_KEY }}"
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,28 +1,30 @@
 name: "Dependency Review"
-on: [push, pull_request, workflow_dispatch]
+
+on: [pull_request, workflow_dispatch]
+
 permissions:
   contents: read
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Repository"
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          show-progress: false
-      - name: "Dependency Review"
-        uses: actions/dependency-review-action@v3
-        with:
-          vulnerability-check: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Repository"
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          show-progress: false
+
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.22.2
           go-version-file: go.mod
+
+      # [Info] Shows version of go that is (was) used
+      - run: go version

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,17 +10,20 @@ on:
 jobs:
   tag-release:
     if: ${{ github.repository == 'kubernetes-sigs/aws-iam-authenticator' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ssh-key: "${{ secrets.RELEASE_KEY }}"
-      - run: /usr/bin/git config --global user.email actions@github.com
-      - run: /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
-      - run: hack/tag-release.sh
 
+      - name: Tag release
+        run: |
+          /usr/bin/git config --global user.email actions@github.com
+          /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
+          hack/tag-release.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update CI action versions - removes the deprecated runtime warnings such as
<img width="750" alt="image" src="https://github.com/kubernetes-sigs/aws-iam-authenticator/assets/10913471/220849d0-5937-4bab-adc1-1f6e573199a3">

- Remove `go-version-input` due to redundancy warning
<img width="533" alt="image" src="https://github.com/kubernetes-sigs/aws-iam-authenticator/assets/10913471/de6851eb-2d42-4211-811c-953784a40617">

- Remove `push` trigger from dependency review - theres no point in running this when changes are pushed to `master` since its too late to make any changes at that point and makes it look like `master` is failing a check
<img width="739" alt="image" src="https://github.com/kubernetes-sigs/aws-iam-authenticator/assets/10913471/3565c145-651c-413f-9076-4280c81677d7">

- Replace use of `ubuntu-20.04` with `ubuntu-latest` to ensure OS is kept up to date and for consistency

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

