### PR TITLE
chore: Remove emeritus reviewers from `SECURITY_CONTACTS`

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,11 @@
 approvers:
-- nckturner
 - micahhausler
 - wongma7
 - jyotimahapatra
 - nnmin-aws
 
 reviewers:
-- nckturner
 - micahhausler
-- justinsb
 - wongma7
 - jyotimahapatra
 - nnmin-aws
@@ -18,3 +15,4 @@ emeritus_approvers:
 - mattmoyer
 - mattlandis
 - jaypipes
+- nckturner

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,8 +10,8 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-nckturner
 micahhausler
 wongma7
 jyotimahapatra
+nnmin-aws
 dims


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- Cleanup of emeritus reviewers.

cc @nckturner @justinsb @micahhausler @wongma7 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

