### PR TITLE
Inject log level via CLI flag; add debug logging for incoming requests

### DIFF
--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -59,6 +59,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringP("log-format", "l", "text", "Specify log format to use when logging to stderr [text or json]")
 
+	rootCmd.PersistentFlags().StringP("loglevel", "", "info", "Set the log level (debug, info, warn, error, fatal)")
+
 	rootCmd.PersistentFlags().StringP(
 		"cluster-id",
 		"i",
@@ -75,6 +77,7 @@ func init() {
 
 func initConfig() {
 	logrus.SetFormatter(getLogFormatter())
+	logrus.SetLevel(getLogLevel())
 	if cfgFile == "" {
 		return
 	}
@@ -183,4 +186,16 @@ func getLogFormatter() logrus.Formatter {
 	}
 
 	return &logrus.TextFormatter{FullTimestamp: true}
+}
+
+func getLogLevel() logrus.Level {
+	logLevel, _ := rootCmd.PersistentFlags().GetString("loglevel")
+
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.Warnf("Unknown log format specified (%s), will use default text formatter instead.", logLevel)
+		return logrus.InfoLevel
+	}
+	logrus.Info("Log level set to ", logLevel)
+	return level
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"regexp"
 	"strings"
 	"sync"
@@ -302,6 +303,17 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 		"client": req.RemoteAddr,
 		"method": req.Method,
 	})
+
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		reqDump, err := httputil.DumpRequest(req, true)
+		if err != nil {
+			log.Info(err, "Failed to dump http request")
+		}
+
+		log.WithFields(logrus.Fields{
+			"request": string(reqDump),
+		}).Debug("Request received")
+	}
 
 	if req.Method != http.MethodPost {
 		log.Error("unexpected request method")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Allow users to inject the log level via a `--loglevel` flag. It is `info` by default, which is also the default for the logrus logger.

Adds a debug log statement to log incoming HTTP requests.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A

