### PR TITLE
Add sourceArn to sts through headers

### DIFF
--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -91,6 +91,7 @@ func getConfig() (config.Config, error) {
 		PartitionID:                       viper.GetString("server.partition"),
 		ClusterID:                         viper.GetString("clusterID"),
 		ServerEC2DescribeInstancesRoleARN: viper.GetString("server.ec2DescribeInstancesRoleARN"),
+		SourceARN:                         viper.GetString("server.sourceARN"),
 		HostPort:                          viper.GetInt("server.port"),
 		Hostname:                          viper.GetString("server.hostname"),
 		GenerateKubeconfigPath:            viper.GetString("server.generateKubeconfig"),

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -155,6 +155,12 @@ type Config struct {
 	// running.
 	ServerEC2DescribeInstancesRoleARN string
 
+	// SourceARN is value which is passed while assuming role specified by ServerEC2DescribeInstancesRoleARN.
+	// When a service assumes a role in your account, you can include the aws:SourceAccount and aws:SourceArn global
+	// condition context keys in your role trust policy to limit access to the role to only requests that are generated
+	// by expected resources. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+	SourceARN string
+
 	// Address defines the hostname or IP Address to bind the HTTPS server to listen to. This is useful when creating
 	// a local server to handle the authentication request for development.
 	Address string

--- a/pkg/ec2provider/ec2provider_test.go
+++ b/pkg/ec2provider/ec2provider_test.go
@@ -150,3 +150,44 @@ func prepare100InstanceOutput() []*ec2.Reservation {
 	return reservations
 
 }
+
+func TestGetSourceAcctAndArn(t *testing.T) {
+	type args struct {
+		roleARN string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "corect role arn",
+			args: args{
+				roleARN: "arn:aws:iam::123456789876:role/test-cluster",
+			},
+			want:    "123456789876",
+			wantErr: false,
+		},
+		{
+			name: "incorect role arn",
+			args: args{
+				roleARN: "arn:aws:iam::123456789876",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getSourceAccount(tt.args.roleARN)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetSourceAccount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetSourceAccount() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -207,7 +207,7 @@ func (c *Server) getHandler(backendMapper BackendMapper, ec2DescribeQps int, ec2
 
 	h := &handler{
 		verifier:                  token.NewVerifier(c.ClusterID, c.PartitionID, instanceRegion),
-		ec2Provider:               ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
+		ec2Provider:               ec2provider.New(c.ServerEC2DescribeInstancesRoleARN, c.SourceARN, instanceRegion, ec2DescribeQps, ec2DescribeBurst),
 		clusterID:                 c.ClusterID,
 		backendMapper:             backendMapper,
 		scrubbedAccounts:          c.Config.ScrubbedAWSAccounts,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add cluster details (clusters_arn and account_id) as headers to STS when assuming a role to make requests. When sourceARN is not empty, it will panic if it fails to parse account id from the sourceARN (same behavior as verifying roleARN).

The reason to add sourceArn and sourceAccount to STS request headers is to avoid confusion deputy issue. AWS IAM supports these global conditional key in IAM roles trust policy https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html, and we want to include the caller identity into the STS requests when assuming the role. We have did same change for CCM in https://github.com/kubernetes/cloud-provider-aws/pull/649

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

