### PR TITLE
Fix x-amz-expires header value

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -322,7 +322,7 @@ func (g generator) GetWithSTS(clusterID string, stsAPI stsiface.STSAPI) (Token, 
 	// parameter is a required argument to Presign(), and authenticators 0.3.0 and older are expecting a value between
 	// 0 and 60 on the server side).
 	// https://github.com/aws/aws-sdk-go/issues/2167
-	presignedURLString, err := request.Presign(requestPresignParam)
+	presignedURLString, err := request.Presign(requestPresignParam * time.Second)
 	if err != nil {
 		return Token{}, err
 	}

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -611,7 +611,7 @@ func TestGetWithSTS(t *testing.T) {
 			}(),
 			time.Unix(1682640000, 0),
 			Token{
-				Token:      "k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtd2VzdC0yLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BU0lBUjJURzQ0VjZBUzNaWkU3QyUyRjIwMjMwNDI4JTJGdXMtd2VzdC0yJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzA0MjhUMDAwMDAwWiZYLUFtei1FeHBpcmVzPTAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JTNCeC1rOHMtYXdzLWlkJlgtQW16LVNpZ25hdHVyZT00ZDdhYmZkZTk2NzI1ZWI4YTc3MzgyNDg0MTZlNGI1ZDA4ZDlkYmQ3MThiNGY2ZGQ2OTBmOGZiNzUwMTMyOWQ1",
+				Token:      "k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtd2VzdC0yLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BU0lBUjJURzQ0VjZBUzNaWkU3QyUyRjIwMjMwNDI4JTJGdXMtd2VzdC0yJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzA0MjhUMDAwMDAwWiZYLUFtei1FeHBpcmVzPTYwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCUzQngtazhzLWF3cy1pZCZYLUFtei1TaWduYXR1cmU9ZTIxMWRiYTc3YWJhOWRjNDRiMGI2YmUzOGI4ZWFhZDA5MjU5OWM1MTU3ZjYzMTQ0NDRjNWI5ZDg1NzQ3ZjVjZQ",
 				Expiration: time.Unix(1682640000, 0).Local().Add(time.Minute * 14),
 			},
 			nil,
@@ -639,6 +639,8 @@ func TestGetWithSTS(t *testing.T) {
 				t.Errorf("Unexpected error: %s", diff)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
+				fmt.Printf("Want: %s\n", tc.want)
+				fmt.Printf("Got: %s\n", got)
 				t.Errorf("Got unexpected token: %s", diff)
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

While working on #736, I noticed that the current authenticator is setting x-amz-expires header to 60 _nanoseconds_ instead of 60 seconds. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This value is ignored by STS, but this changes the signed header value to not be `0`, but now be `60` seconds.

