### PR TITLE
Filecache sdk upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.5
 
 require (
 	github.com/aws/aws-sdk-go v1.54.6
+	github.com/aws/aws-sdk-go-v2 v1.30.4
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gofrs/flock v0.8.1
 	github.com/google/go-cmp v0.6.0
@@ -25,6 +26,7 @@ require (
 )
 
 require (
+	github.com/aws/smithy-go v1.20.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/aws/aws-sdk-go v1.54.6 h1:HEYUib3yTt8E6vxjMWM3yAq5b+qjj/6aKA62mkgux9g=
 github.com/aws/aws-sdk-go v1.54.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go-v2 v1.30.4 h1:frhcagrVNrzmT95RJImMHgabt99vkXGslubDaDagTk8=
+github.com/aws/aws-sdk-go-v2 v1.30.4/go.mod h1:CT+ZPWXbYrci8chcARI3OmI/qgd+f6WtuLOoaIA8PR0=
+github.com/aws/smithy-go v1.20.4 h1:2HK1zBdPgRbjFOHlfeQZfpC4r72MOb9bZkiFwggKO+4=
+github.com/aws/smithy-go v1.20.4/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/filecache/converter.go
+++ b/pkg/filecache/converter.go
@@ -1,0 +1,55 @@
+package filecache
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+type v2 struct {
+	creds *credentials.Credentials
+}
+
+var _ aws.CredentialsProvider = &v2{}
+
+func (p *v2) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	val, err := p.creds.GetWithContext(ctx)
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+	resp := aws.Credentials{
+		AccessKeyID:     val.AccessKeyID,
+		SecretAccessKey: val.SecretAccessKey,
+		SessionToken:    val.SessionToken,
+		Source:          val.ProviderName,
+		CanExpire:       false,
+		// Don't have account ID
+	}
+
+	if expiration, err := p.creds.ExpiresAt(); err != nil {
+		resp.CanExpire = true
+		resp.Expires = expiration
+	}
+	return resp, nil
+}
+
+// V1ProviderToV2Provider converts a v1 credentials.Provider to a v2 aws.CredentialsProvider
+func V1ProviderToV2Provider(p credentials.Provider) aws.CredentialsProvider {
+	return V1CredentialToV2Provider(credentials.NewCredentials(p))
+}
+
+// V1CredentialToV2Provider converts a v1 credentials.Credential to a v2 aws.CredentialProvider
+func V1CredentialToV2Provider(c *credentials.Credentials) aws.CredentialsProvider {
+	return &v2{creds: c}
+}
+
+// V2CredentialToV1Value converts a v2 aws.Credentials to a v1 credentials.Value
+func V2CredentialToV1Value(cred aws.Credentials) credentials.Value {
+	return credentials.Value{
+		AccessKeyID:     cred.AccessKeyID,
+		SecretAccessKey: cred.SecretAccessKey,
+		SessionToken:    cred.SessionToken,
+		ProviderName:    cred.Source,
+	}
+}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -248,7 +248,11 @@ func (g generator) GetWithOptions(options *GetTokenOptions) (Token, error) {
 			profile = session.DefaultSharedConfigProfile
 		}
 		// create a cacheing Provider wrapper around the Credentials
-		if cacheProvider, err := filecache.NewFileCacheProvider(options.ClusterID, profile, options.AssumeRoleARN, sess.Config.Credentials); err == nil {
+		if cacheProvider, err := filecache.NewFileCacheProvider(
+			options.ClusterID,
+			profile,
+			options.AssumeRoleARN,
+			filecache.V1CredentialToV2Provider(sess.Config.Credentials)); err == nil {
 			sess.Config.Credentials = credentials.NewCredentials(cacheProvider)
 		} else {
 			fmt.Fprintf(os.Stderr, "unable to use cache: %v\n", err)

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
+	github.com/aws/aws-sdk-go-v2 v1.30.4 // indirect
+	github.com/aws/smithy-go v1.20.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/tests/integration/go.sum
+++ b/tests/integration/go.sum
@@ -12,6 +12,10 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.54.6 h1:HEYUib3yTt8E6vxjMWM3yAq5b+qjj/6aKA62mkgux9g=
 github.com/aws/aws-sdk-go v1.54.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go-v2 v1.30.4 h1:frhcagrVNrzmT95RJImMHgabt99vkXGslubDaDagTk8=
+github.com/aws/aws-sdk-go-v2 v1.30.4/go.mod h1:CT+ZPWXbYrci8chcARI3OmI/qgd+f6WtuLOoaIA8PR0=
+github.com/aws/smithy-go v1.20.4 h1:2HK1zBdPgRbjFOHlfeQZfpC4r72MOb9bZkiFwggKO+4=
+github.com/aws/smithy-go v1.20.4/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=


### PR DESCRIPTION

**What this PR does / why we need it**:
Update filecache to use AWS SDK Go V2 with wrappers
    
This changes updates filecache's internal types to use the AWS SDK Go  v2's types, while preserving the external interface used by /pkg/token.This will simplify the future project-wide change for AWS SDK Go v2.

Depends on #755 to be merged first

**Which issue(s) this PR fixes** 

First change toward #736 

