### PR TITLE
use protobuf content type instead of json for k8s client

### DIFF
--- a/cmd/aws-iam-authenticator/add.go
+++ b/cmd/aws-iam-authenticator/add.go
@@ -193,6 +193,8 @@ func createClient() client.Client {
 			os.Exit(1)
 		}
 	}
+	kcfg.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	kcfg.ContentType = "application/vnd.kubernetes.protobuf"
 	clientset, err := kubernetes.NewForConfig(kcfg)
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -38,6 +38,8 @@ func New(masterURL, kubeConfig string) (*MapStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	clientconfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	clientconfig.ContentType = "application/vnd.kubernetes.protobuf"
 	clientset, err := kubernetes.NewForConfig(clientconfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This MR is a part of effort to elevate single eks cluster performance by migrating the EKS components to use protobuf instead of json.

Modify kubeconfig type to use content type application/vnd.kubernetes.protobuf instead of json for performance gain.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

