### PR TITLE
Added accountID to throttled error log

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -333,9 +333,9 @@ func (h *handler) authenticateEndpoint(w http.ResponseWriter, req *http.Request)
 	// if the token is invalid, reject with a 403
 	identity, err := h.verifier.Verify(tokenReview.Spec.Token)
 	if err != nil {
-		if _, ok := err.(token.STSThrottling); ok {
+		if throttleErr, ok := err.(token.STSThrottling); ok {
 			metrics.Get().Latency.WithLabelValues(metrics.STSThrottling).Observe(duration(start))
-			log.WithError(err).Warn("access denied")
+			log.WithError(throttleErr).WithField("accountID", throttleErr.AccountID()).Warn("access denied")
 			w.WriteHeader(http.StatusTooManyRequests)
 			w.Write(tokenReviewDenyJSON)
 			return

--- a/pkg/token/akid.go
+++ b/pkg/token/akid.go
@@ -1,0 +1,39 @@
+package token
+
+import (
+	"encoding/base32"
+	"encoding/hex"
+	"fmt"
+)
+
+// accountForAKID is a best-effort method to extract the account ID from an AKID for
+// logging on throttled requests. This should not be called on untrusted input (i.e.
+// AKID from the request before validating the request from STS).
+//
+// This is not foolproof, but avoids an `sts:GetAccessKeyInfo` call per AKID.
+// adapted from https://hackingthe.cloud/aws/enumeration/get-account-id-from-keys/
+func accountForAKID(akid string) string {
+	if len(akid) < 20 {
+		// too short
+		return ""
+	}
+	decoded, err := base32.StdEncoding.DecodeString(akid[4:])
+	if err != nil {
+		// decoding error
+		return ""
+	}
+	y := decoded[:6]
+	z := uint64(0)
+	for i := 0; i < len(y); i++ {
+		z = (z << 8) | uint64(y[i])
+	}
+	// this mask bytestring is always valid
+	maskBytes, _ := hex.DecodeString("7fffffffff80")
+	mask := uint64(0)
+	for i := 0; i < len(maskBytes); i++ {
+		mask = (mask << 8) | uint64(maskBytes[i])
+	}
+	// Apply mask and shift right by 7 bits
+	e := (z & mask) >> 7
+	return fmt.Sprintf("%012d", e)
+}

--- a/pkg/token/akid_test.go
+++ b/pkg/token/akid_test.go
@@ -1,0 +1,44 @@
+package token
+
+import (
+	"testing"
+)
+
+func TestAccountForAKID(t *testing.T) {
+	testcases := []struct {
+		name     string
+		akid     string
+		expected string
+		wantErr  error
+	}{
+		{
+			name:     "empty akid",
+			akid:     "",
+			expected: "",
+		},
+		{
+			name:     "akid with account",
+			akid:     "ASIAR2TG44V5PDTTBZRR",
+			expected: "125843596666",
+		},
+		{
+			name:     "account starting with a 0",
+			akid:     "ASIAQNZGKIQY56JQ7WML",
+			expected: "029608264753",
+		},
+		{
+			name:     "non base32 encoded akid",
+			akid:     "ASIAc29tZXRoaW5nCg==",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := accountForAKID(tc.akid)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -209,7 +209,7 @@ func TestVerifyTokenPreSTSValidations(t *testing.T) {
 func TestVerifyHTTPThrottling(t *testing.T) {
 	testVerifier := newVerifier("aws", 400, "{\\\"Error\\\":{\\\"Code\\\":\\\"Throttling\\\",\\\"Message\\\":\\\"Rate exceeded\\\",\\\"Type\\\":\\\"Sender\\\"},\\\"RequestId\\\":\\\"8c2d3520-24e1-4d5c-ac55-7e226335f447\\\"}", nil)
 	_, err := testVerifier.Verify(validToken)
-	errorContains(t, err, "sts getCallerIdentity was throttled")
+	errorContains(t, err, "sts getCallerIdentity for account 073224499664 was throttled")
 	assertSTSThrottling(t, err)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds extra context into throttled error logging. Since a presigned URL can come from any account, its not clear in logs or metrics which account is getting throttled. This adds more context for debugging throttled denies. We could also add a label to the `StsThrottling` counter metric in `Verify()`, but I wasn't sure off the top of my head if EKS is set up to handle a new metric dimension on that counter. I _think_ it'll still retain the global throttle counter, but we can add that labeled metric in a follow up PR if we want to consume it.
