### PR TITLE
add default timeout for http client

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -457,6 +457,7 @@ func NewVerifier(clusterID, partitionID, region string) Verifier {
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
+			Timeout: 10 * time.Second,
 		},
 		clusterID:         clusterID,
 		validSTShostnames: stsHostsForPartition(partitionID, region),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This would set the http timeout for the requests made to sts inorder to fail fast during an issue. By default the request can be blocked forever if connection is established or timeout after 30 sec if its fails to establish a connection.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

