### PR TITLE
Log level setting + refactor filecache logs to use logrus

### DIFF
--- a/cmd/aws-iam-authenticator/init.go
+++ b/cmd/aws-iam-authenticator/init.go
@@ -21,6 +21,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
@@ -75,6 +76,7 @@ var initCmd = &cobra.Command{
 func init() {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("aws_iam_authenticator")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	initCmd.Flags().String(
 		"hostname",

--- a/cmd/aws-iam-authenticator/init.go
+++ b/cmd/aws-iam-authenticator/init.go
@@ -73,6 +73,9 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("aws_iam_authenticator")
+
 	initCmd.Flags().String(
 		"hostname",
 		"localhost",

--- a/cmd/aws-iam-authenticator/init.go
+++ b/cmd/aws-iam-authenticator/init.go
@@ -21,7 +21,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
@@ -74,10 +73,6 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	viper.AutomaticEnv()
-	viper.SetEnvPrefix("aws_iam_authenticator")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
 	initCmd.Flags().String(
 		"hostname",
 		"localhost",

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -60,8 +60,10 @@ func init() {
 
 	rootCmd.PersistentFlags().StringP("log-format", "l", "text", "Specify log format to use when logging to stderr [text or json]")
 
-	rootCmd.PersistentFlags().String("log-level", "info", "Specify log level to use when logging to stderr ["+strings.Join(getValidLogLevels(), ", ")+"]")
-	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	rootCmd.PersistentFlags().StringP("log-verbosity", "v", "info",
+		"Specify log level to use when logging to stderr ["+strings.Join(getValidLogLevels(), ", ")+"]")
+	viper.BindPFlag("log-verbosity", rootCmd.PersistentFlags().Lookup("log-verbosity"))
+	viper.BindEnv("log-verbosity", "AWS_IAM_AUTHENTICATOR_LOG_VERBOSITY")
 
 	rootCmd.PersistentFlags().StringP(
 		"cluster-id",
@@ -80,7 +82,7 @@ func init() {
 func initConfig() {
 	logrus.SetFormatter(getLogFormatter())
 
-	logLevel := viper.GetString("log-level")
+	logLevel := viper.GetString("log-verbosity")
 	if level, err := logrus.ParseLevel(logLevel); err == nil {
 		logrus.SetLevel(level)
 	} else {
@@ -99,7 +101,6 @@ func initConfig() {
 }
 
 func getConfig() (config.Config, error) {
-
 	cfg := config.Config{
 		PartitionID:                       viper.GetString("server.partition"),
 		ClusterID:                         viper.GetString("clusterID"),
@@ -117,12 +118,12 @@ func getConfig() (config.Config, error) {
 		EC2DescribeInstancesQps:           viper.GetInt("server.ec2DescribeInstancesQps"),
 		EC2DescribeInstancesBurst:         viper.GetInt("server.ec2DescribeInstancesBurst"),
 		ScrubbedAWSAccounts:               viper.GetStringSlice("server.scrubbedAccounts"),
-		//flags for dynamicfile mode
-		//DynamicFilePath: the file path containing the roleMapping and userMapping
+		// flags for dynamicfile mode
+		// DynamicFilePath: the file path containing the roleMapping and userMapping
 		DynamicFilePath: viper.GetString("server.dynamicfilepath"),
-		//DynamicFileUserIDStrict: if true, then aws UserId from sts will be used to look up the roleMapping/userMapping; or aws IdentityArn is used
+		// DynamicFileUserIDStrict: if true, then aws UserId from sts will be used to look up the roleMapping/userMapping; or aws IdentityArn is used
 		DynamicFileUserIDStrict: viper.GetBool("server.dynamicfileUserIDStrict"),
-		//DynamicBackendModePath: the file path containing the backend mode
+		// DynamicBackendModePath: the file path containing the backend mode
 		DynamicBackendModePath: viper.GetString("server.dynamicBackendModePath"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &cfg.RoleMappings); err != nil {

--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -57,6 +57,9 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Load configuration from `filename`")
 
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Reduce output verbosity")
+	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
+
 	rootCmd.PersistentFlags().StringP("log-format", "l", "text", "Specify log format to use when logging to stderr [text or json]")
 
 	rootCmd.PersistentFlags().StringP(

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -13,8 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/gofrs/flock"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -192,7 +192,7 @@ func NewFileCacheProvider(clusterID, profile, roleARN string, provider aws.Crede
 	} else {
 		if errors.Is(err, fs.ErrNotExist) {
 			// cache file is missing.  maybe this is the very first run?  continue to use cache.
-			_, _ = fmt.Fprintf(os.Stderr, "Cache file %s does not exist.\n", resp.filename)
+			logrus.Warnf("Cache file %s does not exist.", resp.filename)
 		} else {
 			return nil, fmt.Errorf("couldn't stat cache file: %w", err)
 		}
@@ -212,15 +212,11 @@ func (f *FileCacheProvider) Retrieve() (credentials.Value, error) {
 // otherwise fetching the credential from the underlying Provider and caching the results on disk
 // with an expiration time.
 func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credentials.Value, error) {
-	var quiet bool = viper.GetBool("quiet")
-
 	if !f.cachedCredential.Expired() && f.cachedCredential.HasKeys() {
 		// use the cached credential
 		return V2CredentialToV1Value(f.cachedCredential), nil
 	} else {
-		if !quiet {
-			_, _ = fmt.Fprintf(os.Stderr, "No cached credential available.  Refreshing...\n")
-		}
+		logrus.Info("No cached credential available. Refreshing...")
 		// fetch the credentials from the underlying Provider
 		credential, err := f.provider.Retrieve(ctx)
 		if err != nil {
@@ -239,7 +235,7 @@ func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credential
 			ok, err := lock.TryLockContext(ctx, 250*time.Millisecond) // try to lock every 1/4 second
 			if !ok {
 				// can't get write lock to create/update cache, but still return the credential
-				_, _ = fmt.Fprintf(os.Stderr, "Unable to write lock file %s: %v\n", f.filename, err)
+				logrus.Warnf("Unable to write lock file %s: %v", f.filename, err)
 				return V2CredentialToV1Value(credential), nil
 			}
 			f.cachedCredential = credential
@@ -249,14 +245,14 @@ func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credential
 			err = writeCacheWhileLocked(f.fs, f.filename, cache)
 			if err != nil {
 				// can't write cache, but still return the credential
-				_, _ = fmt.Fprintf(os.Stderr, "Unable to update credential cache %s: %v\n", f.filename, err)
+				logrus.Warnf("Unable to update credential cache %s: %v", f.filename, err)
 				err = nil
-			} else if !quiet {
-				_, _ = fmt.Fprintf(os.Stderr, "Updated cached credential\n")
+			} else {
+				logrus.Info("Updated cached credential")
 			}
 		} else {
 			// credential doesn't support expiration time, so can't cache, but still return the credential
-			_, _ = fmt.Fprint(os.Stderr, "Unable to cache credential: credential doesn't support expiration\n")
+			logrus.Warn("Unable to cache credential: credential doesn't support expiration")
 		}
 		return V2CredentialToV1Value(credential), err
 	}

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -216,7 +216,7 @@ func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credential
 		// use the cached credential
 		return V2CredentialToV1Value(f.cachedCredential), nil
 	} else {
-		logrus.Info("No cached credential available. Refreshing...")
+		logrus.Debug("No cached credential available. Refreshing...")
 		// fetch the credentials from the underlying Provider
 		credential, err := f.provider.Retrieve(ctx)
 		if err != nil {
@@ -248,7 +248,7 @@ func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credential
 				logrus.Warnf("Unable to update credential cache %s: %v", f.filename, err)
 				err = nil
 			} else {
-				logrus.Info("Updated cached credential")
+				logrus.Debug("Updated cached credential")
 			}
 		} else {
 			// credential doesn't support expiration time, so can't cache, but still return the credential


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
<del>It adds a `--quiet` global flag, defaulted to the `AWS_IAM_AUTHENTICATOR_QUIET` boolean environment variable.</del>

<del>It currently only removes non error (but still written into stderr) filecache related logs.
Maybe some other logs could be concerned.</del>

It adds a `--log-verbosity` flag to configure the minimum log level to display and fixes the filecache raw prints into using logrus like other logs.

<del>I've also enabled the viper AutomaticEnv mode, which cleanly handles env vars with a common prefix.
The undocumented `KUBERNETES_AWS_AUTHENTICATOR_CLUSTER_ID` env flag should probably be refactored, but I didn't want to introduce a breaking change.</del>

I've also moved the following cache logs to the debug level, because the default cache output should be clean when no problem occurs. One still can display them by using the new verbosity flag when debugging the cache behavior:

```
DEBU[2025-06-02T15:01:32+02:00] No cached credential available. Refreshing...
DEBU[2025-06-02T15:01:33+02:00] Updated cached credential
```

**Which issue(s) this PR fixes**
Fixes #771 