### PR TITLE
Fix credential expirability check

### DIFF
--- a/pkg/filecache/converter.go
+++ b/pkg/filecache/converter.go
@@ -27,7 +27,7 @@ func (p *v2) Retrieve(ctx context.Context) (aws.Credentials, error) {
 		// Don't have account ID
 	}
 
-	if expiration, err := p.creds.ExpiresAt(); err != nil {
+	if expiration, err := p.creds.ExpiresAt(); err == nil {
 		resp.CanExpire = true
 		resp.Expires = expiration
 	}

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -252,7 +252,6 @@ func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credential
 		} else {
 			// credential doesn't support expiration time, so can't cache, but still return the credential
 			_, _ = fmt.Fprint(os.Stderr, "Unable to cache credential: credential doesn't support expiration\n")
-			err = nil
 		}
 		return V2CredentialToV1Value(credential), err
 	}

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -251,7 +251,7 @@ func (f *FileCacheProvider) RetrieveWithContext(ctx context.Context) (credential
 			}
 		} else {
 			// credential doesn't support expiration time, so can't cache, but still return the credential
-			_, _ = fmt.Fprintf(os.Stderr, "Unable to cache credential: %v\n", err)
+			_, _ = fmt.Fprint(os.Stderr, "Unable to cache credential: credential doesn't support expiration\n")
 			err = nil
 		}
 		return V2CredentialToV1Value(credential), err


### PR DESCRIPTION
Fixes a bug introduced during the refactor in e92213c081fdf30686b3bc962d9ee642ce57f245, which incorrectly inverted the previous credential expirability checking logic. This caused errors about being unable to cache otherwise cachable credentials. Also changes the error log around the previous expirability check site to no longer log the error that previously came from the `ExpiresAt()` check; since this is now the wrong `err`, it's always `nil`.

Addresses #776
