### PR TITLE
handle scenario when the file is created but doesn't have content

### DIFF
--- a/pkg/fileutil/util.go
+++ b/pkg/fileutil/util.go
@@ -58,6 +58,7 @@ func StartLoadDynamicFile(filename string, callBack FileChangeCallBack, stopCh <
 		defer watcher.Close()
 		content, err := loadDynamicFile(filename, stopCh)
 		if err != nil {
+			logrus.Errorf("startLoadDynamicFile: failed when loading file %s, %v", filename, err)
 			return
 		}
 		err = watcher.Add(filename)
@@ -68,6 +69,7 @@ func StartLoadDynamicFile(filename string, callBack FileChangeCallBack, stopCh <
 		}
 		if err := callBack.CallBackForFileLoad(content); err != nil {
 			logrus.Errorf("StartLoadDynamicFile: error in callBackForFileLoad, %v", err)
+			return
 		}
 		for {
 			select {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

If the dynamic file is present but does't have the correct/no data, then authenticator would be stuck in for loop waiting for any file event and until that happens would not have the latest changes. If this happens during the start then it would be failing requests until the file is updated and new changes are reloaded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

