### PR TITLE
chore: Add dependabot configuration to automatically check for package updates weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,59 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - '**/*'
+    allow:
+      - dependency-type: 'all'
+    schedule:
+      interval: weekly
+      day: 'monday'
+      time: '06:00'
+      timezone: 'US/Pacific'
+    groups:
+      aws-dependencies:
+        patterns:
+          - 'github.com/aws/*'
+      k8s-dependencies:
+        patterns:
+          - 'k8s.io*'
+          - 'sigs.k8s.io*'
+      misc-dependencies:
+        patterns:
+          - '*'
+        exclude-patterns:
+          - 'github.com/aws/*'
+          - 'k8s.io*'
+          - 'sigs.k8s.io*'
+    labels:
+      - 'area/dependency'
+      - 'ok-to-test'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: 'monday'
+      time: '06:00'
+      timezone: 'US/Pacific'
+    groups:
+      actions:
+        patterns:
+          - '*'
+    labels:
+      - 'area/dependency'
+      - 'ok-to-test'


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add dependabot configuration to automatically check for package updates weekly
  - Pinched the one from [ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/dependabot.yaml) and modified to add a separate group for AWS packages and directory traversal for the `tests/e2e` and `tests/integration` directories to be updated in sync with the root module

Current schedule is for 6:00am PST every Monday but open to suggestions on what the best time/frequency is for the team.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

