### PR TITLE
Enhancement: Watch channel logging - clarify reconnection behavior

### DIFF
--- a/pkg/mapper/configmap/configmap.go
+++ b/pkg/mapper/configmap/configmap.go
@@ -101,7 +101,7 @@ func (ms *MapStore) startLoadConfigMap(stopCh <-chan struct{}) {
 
 					}
 				}
-				logrus.Error("Watch channel closed.")
+				logrus.Warn("Watch channel closed. Reconnecting...")
 			}
 		}
 	}()


### PR DESCRIPTION
# Enhancement: clarify watch channel reconnection log message

Changes the log message for watch channel closure from an error to a warning level and adds context about the automatic reconnection behavior. This better reflects the expected behavior of the watch loop and provides clearer observability.

Before: `logrus.Error("Watch channel closed.")`
After:  `logrus.Warn("Watch channel closed. Reconnecting...")`

**What this PR does / why we need it**:
Updates watch channel logging to be more informative and use appropriate log level. The current error message "Watch channel closed" has caused customer confusion and support tickets since it doesn't indicate that this is an expected behavior with automatic recovery.

The change:
- Reduces log severity from ERROR to WARN since this is a handled condition
- Adds context that the system will automatically reconnect
- Helps avoid unnecessary support escalations
- Better reflects the actual behavior of the watch loop

**Context**:
We've received support cases where customers are concerned about the "Watch channel closed" error message in their logs. While the watch channel closure and reconnection is a normal part of Kubernetes controller operation (especially during network blips or API server changes), the current error-level log message doesn't communicate this and can cause unnecessary alarm.

The updated message better communicates that:
1. This is an expected occasional occurrence
2. The system handles it automatically
3. No manual intervention is required




