### PR TITLE
Adds http2 support

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,6 +133,7 @@ func New(cfg config.Config, stopCh <-chan struct{}) *Server {
 	listener, err := tls.Listen("tcp", c.ListenAddr(), &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{*cert},
+		NextProtos:   []string{"h2", "http/1.1"},
 	})
 	if err != nil {
 		logrus.WithError(err).Fatal("could not open TLS listener")


### PR DESCRIPTION
This PR adds http2 support for authenticator webhook server, before this change, http2 requests will be rejected:

```
$ curl -v --http2-prior-knowledge https://localhost:21362/ --insecure
> GET / HTTP/2
> Host: localhost:21362
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
* Remote peer returned unexpected data while we expected SETTINGS frame.  Perhaps, peer does not support HTTP/2 properly.
* Closing connection
curl: (16) Remote peer returned unexpected data while we expected SETTINGS frame.  Perhaps, peer does not support HTTP/2 properly.
```

After this PR, http2 calls will be accepted:

```
* Connected to localhost (127.0.0.1) port 21362
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
```