### PR TITLE
Cherrypick(release-0.6): Adds http2 support

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,6 +133,7 @@ func New(cfg config.Config, stopCh <-chan struct{}) *Server {
 	listener, err := tls.Listen("tcp", c.ListenAddr(), &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{*cert},
+		NextProtos:   []string{"h2", "http/1.1"},
 	})
 	if err != nil {
 		logrus.WithError(err).Fatal("could not open TLS listener")


### PR DESCRIPTION
Cherrypicks https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/826 to release-0.6