### PR TITLE
remove validations on release branch

### DIFF
--- a/hack/tag-release.sh
+++ b/hack/tag-release.sh
@@ -21,21 +21,6 @@ if [[ ! "${VERSION}" =~ ^([0-9]+[.][0-9]+)[.]([0-9]+)(-(alpha|beta)[.]([0-9]+))?
   exit 1
 fi
 
-BRANCH=$(git branch --show-current)
-
-if [[ ! "${BRANCH}" =~ ^(release-)([0-9]+[.][0-9]+)$ ]]; then
-    echo "Automatic tag creation must take place on a release branch."
-    exit 1
-fi
-
-BRANCH_MAJ_MIN=${BRANCH#release-}
-VERSION_MAJ_MIN=$(echo ${VERSION} | sed -Ee 's/-(alpha|beta)\.[0-9]+$//' | sed -Ee 's/\.[0-9]+$//')
-
-if [[ ! "${BRANCH_MAJ_MIN}" = $VERSION_MAJ_MIN ]]; then
-    echo "Major minor version of tag must match major minor version of branch."
-    exit 1
-fi
-
 if [ "$(git tag -l "v${VERSION}")" ]; then
   echo "Tag v${VERSION} already exists"
   exit 0


### PR DESCRIPTION
This reverts commit 3002a171a4630a2217250f8fb573db6edf9f73a8.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

remove validations on branch while creating a release.

We want to release directly from master branch so these validations are no longer needed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

