### PR TITLE
chore: Move observability dependencies to separate dependabot update group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,11 +33,17 @@ updates:
         patterns:
           - 'k8s.io*'
           - 'sigs.k8s.io*'
+      observability-dependencies:
+        patterns:
+          - 'github.com/prometheus/*'
+          - 'go.opentelemetry.io/*'
       misc-dependencies:
         patterns:
           - '*'
         exclude-patterns:
           - 'github.com/aws/*'
+          - 'github.com/prometheus/*'
+          - 'go.opentelemetry.io/*'
           - 'k8s.io*'
           - 'sigs.k8s.io*'
     labels:


### PR DESCRIPTION

**What this PR does / why we need it**:
- Move observability dependencies to separate dependabot update group

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

- Not a fix per se, but breaks up the `misc` group a bit by separating out the observability packages which tend to cause disruptions/issues more frequently than one would hope https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-iam-authenticator/870/pull-aws-iam-authenticator-integration/1937162696222838784
