### PR TITLE
Migrate STS hostname verification to AWS SDK Go V2

### DIFF
--- a/cmd/aws-iam-authenticator/root.go
+++ b/cmd/aws-iam-authenticator/root.go
@@ -20,17 +20,18 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/endpoints"
 )
 
 var cfgFile string
@@ -157,13 +158,7 @@ func getConfig() (config.Config, error) {
 		return cfg, errors.New("cluster ID cannot be empty")
 	}
 
-	partitionKeys := []string{}
-	partitionMap := map[string]endpoints.Partition{}
-	for _, p := range endpoints.DefaultPartitions() {
-		partitionMap[p.ID()] = p
-		partitionKeys = append(partitionKeys, p.ID())
-	}
-	if _, ok := partitionMap[cfg.PartitionID]; !ok {
+	if !slices.Contains(endpoints.PARTITIONS, cfg.PartitionID) {
 		return cfg, errors.New("Invalid partition")
 	}
 

--- a/cmd/aws-iam-authenticator/server.go
+++ b/cmd/aws-iam-authenticator/server.go
@@ -29,11 +29,11 @@ import (
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/server"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/endpoints"
 )
 
 const (
@@ -67,14 +67,9 @@ var serverCmd = &cobra.Command{
 }
 
 func init() {
-	partitionKeys := []string{}
-	for _, p := range endpoints.DefaultPartitions() {
-		partitionKeys = append(partitionKeys, p.ID())
-	}
-
 	serverCmd.Flags().String("partition",
 		endpoints.AwsPartitionID,
-		fmt.Sprintf("The AWS partition. Must be one of: %v", partitionKeys))
+		fmt.Sprintf("The AWS partition. Must be one of: %v", endpoints.PARTITIONS))
 	viper.BindPFlag("server.partition", serverCmd.Flags().Lookup("partition"))
 
 	serverCmd.Flags().String("generate-kubeconfig",

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module sigs.k8s.io/aws-iam-authenticator
 go 1.24.4
 
 require (
-	github.com/aws/aws-sdk-go v1.55.7
 	github.com/aws/aws-sdk-go-v2 v1.36.6
 	github.com/aws/aws-sdk-go-v2/config v1.29.18
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.71
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.233.1
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.235.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.1
 	github.com/aws/smithy-go v1.22.4
 	github.com/fsnotify/fsnotify v1.9.0
@@ -55,7 +54,6 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
-github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.6 h1:zJqGjVbRdTPojeCGWn5IR5pbJwSQSBh5RWFTQcEQGdU=
 github.com/aws/aws-sdk-go-v2 v1.36.6/go.mod h1:EYrzvCCN9CMUTa5+6lf6MM4tq3Zjp8UhSGR/cBsjai0=
 github.com/aws/aws-sdk-go-v2/config v1.29.18 h1:x4T1GRPnqKV8HMJOMtNktbpQMl3bIsfx8KbqmveUO2I=
@@ -14,8 +12,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37 h1:v+X21AvTb2wZ+ycg1g
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37/go.mod h1:G0uM1kyssELxmJ2VZEfG0q2npObR3BAkF3c1VsfVnfs=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.233.1 h1:1KYEVBXApGIQnXChtqKTZSN6jerkfiFhOApi8TcGs2w=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.233.1/go.mod h1:K7qdQFo+lbGM48aPEyoPfy/VN/xNOA4o8GGczfSXNcQ=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.235.0 h1:TE8LEu5sTuH2fR9Buv8BNXafOSm+CDrQA3DmYSaWX00=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.235.0/go.mod h1:K7qdQFo+lbGM48aPEyoPfy/VN/xNOA4o8GGczfSXNcQ=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.18 h1:vvbXsA2TVO80/KT7ZqCbx934dt6PY+vQ8hZpUZ/cpYg=
@@ -84,10 +82,6 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -230,7 +224,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/arn/arn.go
+++ b/pkg/arn/arn.go
@@ -2,10 +2,11 @@ package arn
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/endpoints"
 )
 
 type PrincipalType int
@@ -101,10 +102,8 @@ func StripPath(arn string) (string, error) {
 }
 
 func checkPartition(partition string) error {
-	for _, p := range endpoints.DefaultPartitions() {
-		if partition == p.ID() {
-			return nil
-		}
+	if !slices.Contains(endpoints.PARTITIONS, partition) {
+		return fmt.Errorf("partition %s is not recognized", partition)
 	}
-	return fmt.Errorf("partition %s is not recognized", partition)
+	return nil
 }

--- a/pkg/endpoints/partitions.go
+++ b/pkg/endpoints/partitions.go
@@ -1,0 +1,76 @@
+package endpoints
+
+import (
+	"fmt"
+)
+
+// Represents the partitions recognized by the github.com/aws/aws-sdk-go/aws/endpoints
+// package. Obtaining these partitions has been deprecated in the AWS SDK Go V2, so this serves as a
+// hardcoded alternative. Source: https://github.com/aws/aws-sdk-go/blob/main/aws/endpoints/defaults.go
+const (
+	AwsPartitionID      = "aws"        // AWS Standard partition.
+	AwsCnPartitionID    = "aws-cn"     // AWS China partition.
+	AwsUsGovPartitionID = "aws-us-gov" // AWS GovCloud (US) partition.
+	AwsIsoPartitionID   = "aws-iso"    // AWS ISO (US) partition.
+	AwsIsoBPartitionID  = "aws-iso-b"  // AWS ISOB (US) partition.
+	AwsIsoEPartitionID  = "aws-iso-e"  // AWS ISOE (Europe) partition.
+	AwsIsoFPartitionID  = "aws-iso-f"  // AWS ISOF partition.
+)
+
+var (
+	PARTITIONS = []string{
+		AwsPartitionID,
+		AwsCnPartitionID,
+		AwsUsGovPartitionID,
+		AwsIsoPartitionID,
+		AwsIsoBPartitionID,
+		AwsIsoEPartitionID,
+		AwsIsoFPartitionID,
+	}
+)
+
+// Returns the STS domain for the given partition. Returns an error
+// if the partition is not recognized.
+func GetSTSPartitionDomain(partition string) (string, error) {
+	var domain string
+
+	switch partition {
+	case AwsPartitionID:
+		domain = "amazonaws.com"
+	case AwsCnPartitionID:
+		domain = "amazonaws.com.cn"
+	case AwsUsGovPartitionID:
+		domain = "amazonaws.com"
+	case AwsIsoPartitionID:
+		domain = "c2s.ic.gov"
+	case AwsIsoBPartitionID:
+		domain = "sc2s.sgov.gov"
+	case AwsIsoEPartitionID:
+		domain = "cloud.adc-e.uk"
+	case AwsIsoFPartitionID:
+		domain = "csp.hci.ic.gov"
+	default:
+		return "", fmt.Errorf("Partition %s not valid", partition)
+	}
+
+	return domain, nil
+}
+
+// Gets the dual stack domain for the given partition. Returns an empty string
+// if the partition does not support dual stack
+func GetSTSDualStackPartitionDomain(partition string) string {
+	var domain string
+
+	switch partition {
+	case AwsPartitionID:
+		domain = "api.aws"
+	case AwsUsGovPartitionID:
+		domain = "api.aws"
+	case AwsCnPartitionID:
+		domain = "api.amazonwebservices.com.cn"
+	default:
+		return ""
+	}
+
+	return domain
+}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -25,8 +25,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -36,7 +39,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,6 +48,7 @@ import (
 	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"sigs.k8s.io/aws-iam-authenticator/pkg"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/arn"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/endpoints"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/filecache"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 )
@@ -418,75 +421,40 @@ type tokenVerifier struct {
 	client            *http.Client
 	clusterID         string
 	validSTShostnames map[string]bool
+	partition         string
+	region            string
+	mutex             sync.RWMutex
 }
 
-func getDefaultHostNameForRegion(partition *endpoints.Partition, region, service string) (string, error) {
-	rep, err := partition.EndpointFor(service, region, endpoints.STSRegionalEndpointOption, endpoints.ResolveUnknownServiceOption)
-	if err != nil {
-		return "", fmt.Errorf("Error resolving endpoint for %s in partition %s. err: %v", region, partition.ID(), err)
+// Returns the hostnames (regular and dualstack) for a service given a certain region and partition.
+// This hostname is not validated, but follows the format of what the hostname would be given
+// these parameters.
+func getDefaultHostNamesForRegion(partition, region, service string) ([]string, error) {
+	if !validateInputRegion(region) {
+		return []string{}, fmt.Errorf("invalid region identifier format provided: %s", region)
 	}
-	parsedURL, err := url.Parse(rep.URL)
+
+	hostnames := []string{}
+
+	partitionDomain, err := endpoints.GetSTSPartitionDomain(partition)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing STS URL %s. err: %v", rep.URL, err)
+		return []string{}, fmt.Errorf("couldn't get domain for partition %s, %w", partition, err)
 	}
-	return parsedURL.Hostname(), nil
+	hostnames = append(hostnames, fmt.Sprintf("%s.%s.%s", service, region, partitionDomain))
+
+	dualStackPartitionDomain := endpoints.GetSTSDualStackPartitionDomain(partition)
+	if dualStackPartitionDomain != "" {
+		hostnames = append(hostnames, fmt.Sprintf("%s.%s.%s", service, region, dualStackPartitionDomain))
+	}
+
+	return hostnames, nil
 }
 
-func stsHostsForPartition(partitionID, region string) map[string]bool {
-	validSTShostnames := map[string]bool{}
-
-	var partition *endpoints.Partition
-	for _, p := range endpoints.DefaultPartitions() {
-		if partitionID == p.ID() {
-			partition = &p
-			break
-		}
-	}
-	if partition == nil {
-		logrus.Errorf("Partition %s not valid", partitionID)
-		return validSTShostnames
-	}
-
-	stsSvc, ok := partition.Services()[stsServiceID]
-	if !ok {
-		logrus.Errorf("STS service not found in partition %s", partitionID)
-		// Add the host of the current instances region if the service doesn't already exists in the partition
-		// so we don't fail if the service is not present in the go sdk but matches the instances region.
-		stsHostName, err := getDefaultHostNameForRegion(partition, region, stsServiceID)
-		if err != nil {
-			logrus.WithError(err).Error("Error getting default hostname")
-		} else {
-			validSTShostnames[stsHostName] = true
-		}
-		return validSTShostnames
-	}
-	stsSvcEndPoints := stsSvc.Endpoints()
-	for epName, ep := range stsSvcEndPoints {
-		rep, err := ep.ResolveEndpoint(endpoints.STSRegionalEndpointOption)
-		if err != nil {
-			logrus.WithError(err).Errorf("Error resolving endpoint for %s in partition %s", epName, partitionID)
-			continue
-		}
-		parsedURL, err := url.Parse(rep.URL)
-		if err != nil {
-			logrus.WithError(err).Errorf("Error parsing STS URL %s", rep.URL)
-			continue
-		}
-		validSTShostnames[parsedURL.Hostname()] = true
-	}
-
-	// Add the host of the current instances region if not already exists so we don't fail if the region is not
-	// present in the go sdk but matches the instances region.
-	if _, ok := stsSvcEndPoints[region]; !ok {
-		stsHostName, err := getDefaultHostNameForRegion(partition, region, stsServiceID)
-		if err != nil {
-			logrus.WithError(err).Error("Error getting default hostname")
-			return validSTShostnames
-		}
-		validSTShostnames[stsHostName] = true
-	}
-
-	return validSTShostnames
+// Ported over from the AWS SDK Go V1 endpoints package, which validated regions as part of endpoint resolution
+// https://github.com/aws/aws-sdk-go/blob/163aada692ed32951f979aacf452ded4c03b8a7c/aws/endpoints/v3model.go#L592
+func validateInputRegion(region string) bool {
+	regionValidationRegex := regexp.MustCompile(`^[[:alnum:]]([[:alnum:]\-]*[[:alnum:]])?$`)
+	return regionValidationRegex.MatchString(region)
 }
 
 // NewVerifier creates a Verifier that is bound to the clusterID and uses the default http client.
@@ -497,7 +465,7 @@ func NewVerifier(clusterID, partitionID, region string) Verifier {
 		metrics.InitMetrics(prometheus.NewRegistry())
 	}
 
-	return tokenVerifier{
+	return &tokenVerifier{
 		client: &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -505,22 +473,124 @@ func NewVerifier(clusterID, partitionID, region string) Verifier {
 			Timeout: 10 * time.Second,
 		},
 		clusterID:         clusterID,
-		validSTShostnames: stsHostsForPartition(partitionID, region),
+		validSTShostnames: make(map[string]bool),
+		partition:         partitionID,
+		region:            region,
 	}
 }
 
-// verify a sts host, doc: http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#sts_region
-func (v tokenVerifier) verifyHost(host string) error {
-	if _, ok := v.validSTShostnames[host]; !ok {
+// Ensures that a given host is following the appropriate STS hostname format, e.g. sts.{region}.{suffix} for
+// the verifier's partition.
+//
+// Does not run any validation, so hostnames that contain invalid regions (e.g. sts.not-a-region.amazonaws.com) or
+// regions where STS/FIPS/Dualstack are not supported will be verified.
+// doc: http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#sts_region
+func (v *tokenVerifier) verifyHost(host string) error {
+	v.mutex.RLock()
+	if _, ok := v.validSTShostnames[host]; ok {
+		v.mutex.RUnlock()
+		return nil
+	}
+	v.mutex.RUnlock()
+
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+
+	// Double-check after acquiring write lock
+	if _, ok := v.validSTShostnames[host]; ok {
+		return nil
+	}
+
+	// If not in cache, verify the hostname format
+	if err := v.verifySTSHostnameFormat(host); err != nil {
+		return err
+	}
+	// Cache the valid hostname for future checks
+	v.validSTShostnames[host] = true
+	return nil
+}
+
+func (v *tokenVerifier) verifySTSHostnameFormat(host string) error {
+	hostRegion, err := getStsRegion(host)
+	if err != nil {
+		return FormatError{fmt.Sprintf("could not parse region for pre-signed URL %s, %v", host, err)}
+	}
+	if hostRegion == "global" && v.partition == endpoints.AwsPartitionID {
+		return nil
+	} else if hostRegion == "global" && v.partition != endpoints.AwsPartitionID {
+		return FormatError{fmt.Sprintf("global endpoint unsupported in partition %s", v.partition)}
+	}
+	// Ensure that the region follows valid formatting, as was done in the Go SDK V1:
+	// https://github.com/aws/aws-sdk-go/blob/163aada692ed32951f979aacf452ded4c03b8a7c/aws/endpoints/v3model.go#L500
+	if !validateInputRegion(hostRegion) {
+		return FormatError{fmt.Sprintf("invalid region identifier format provided: %s", hostRegion)}
+	}
+
+	stsResolver := sts.NewDefaultEndpointResolverV2()
+
+	// Generate all possible endpoints given this region
+	var resolvedHosts []string
+	options := []bool{true, false}
+	for _, useFIPS := range options {
+		for _, useDualStack := range options {
+			// If the resolver cannot find the region in any partition, it will fall back to the commerical
+			// format, resulting in something like sts.{region}.amazonaws.com. So, if the hostRegion is invalid
+			// or unsupported by STS, then we expect to see an endpoint that follows the commerical partition format.
+			endpoint, err := stsResolver.ResolveEndpoint(context.TODO(), sts.EndpointParameters{
+				Region:       aws.String(hostRegion),
+				UseFIPS:      aws.Bool(useFIPS),
+				UseDualStack: aws.Bool(useDualStack),
+			})
+			if err != nil {
+				continue
+			}
+
+			resolvedHosts = append(resolvedHosts, endpoint.URI.Host)
+		}
+	}
+
+	if !slices.Contains(resolvedHosts, host) {
+		// If neither of them match the host, check what the hostname should be using the given region and partition.
+		// This is to account for regions that aren't yet supported by the SDK, but are
+		// present in the instance metadata.
+		defaultHostnames, err := getDefaultHostNamesForRegion(v.partition, v.region, stsServiceID)
+		if err != nil {
+			logrus.Infof("Error resolving default hostnames for partition %s, region %s, %v", v.partition, v.region, err)
+			return FormatError{fmt.Sprintf("unexpected hostname %q in pre-signed URL", host)}
+		}
+
+		if slices.Contains(defaultHostnames, host) {
+			return nil
+		}
 		return FormatError{fmt.Sprintf("unexpected hostname %q in pre-signed URL", host)}
 	}
+
+	// Verify that the hostname's domain matches that of the verifier's partition
+	// Hostname format: sts.{region_identifier}.{partition_domain}
+	// (source https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html)
+	parts := strings.Split(host, ".")
+	if len(parts) < 4 {
+		return fmt.Errorf("invalid host format, too few labels: %v", host)
+	}
+	actualDomain := strings.Join(parts[2:], ".")
+
+	expectedDomain, err := endpoints.GetSTSPartitionDomain(v.partition)
+	if err != nil {
+		return err
+	}
+	expectedDualStackDomain := endpoints.GetSTSDualStackPartitionDomain(v.partition)
+
+	if actualDomain != expectedDomain && actualDomain != expectedDualStackDomain {
+		return FormatError{fmt.Sprintf("partition {%s} does not support hostname %s", v.partition, host)}
+	}
+
 	return nil
 }
 
 // Verify a token is valid for the specified clusterID. On success, returns an
 // Identity that contains information about the AWS principal that created the
 // token. On failure, returns nil and a non-nil error.
-func (v tokenVerifier) Verify(token string) (*Identity, error) {
+func (v *tokenVerifier) Verify(token string) (*Identity, error) {
 	if len(token) > maxTokenLenBytes {
 		return nil, FormatError{"token is too large"}
 	}

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -3,7 +3,6 @@ module sigs.k8s.io/aws-iam-authenticator/tests/integration
 go 1.24.4
 
 require (
-	github.com/aws/aws-sdk-go v1.55.7
 	github.com/prometheus/client_golang v1.22.0
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.33.3
@@ -25,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.233.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.235.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.6 // indirect

--- a/tests/integration/go.sum
+++ b/tests/integration/go.sum
@@ -10,8 +10,6 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
-github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.6 h1:zJqGjVbRdTPojeCGWn5IR5pbJwSQSBh5RWFTQcEQGdU=
 github.com/aws/aws-sdk-go-v2 v1.36.6/go.mod h1:EYrzvCCN9CMUTa5+6lf6MM4tq3Zjp8UhSGR/cBsjai0=
 github.com/aws/aws-sdk-go-v2/config v1.29.18 h1:x4T1GRPnqKV8HMJOMtNktbpQMl3bIsfx8KbqmveUO2I=
@@ -26,8 +24,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37 h1:v+X21AvTb2wZ+ycg1g
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37/go.mod h1:G0uM1kyssELxmJ2VZEfG0q2npObR3BAkF3c1VsfVnfs=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.233.1 h1:1KYEVBXApGIQnXChtqKTZSN6jerkfiFhOApi8TcGs2w=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.233.1/go.mod h1:K7qdQFo+lbGM48aPEyoPfy/VN/xNOA4o8GGczfSXNcQ=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.235.0 h1:TE8LEu5sTuH2fR9Buv8BNXafOSm+CDrQA3DmYSaWX00=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.235.0/go.mod h1:K7qdQFo+lbGM48aPEyoPfy/VN/xNOA4o8GGczfSXNcQ=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.18 h1:vvbXsA2TVO80/KT7ZqCbx934dt6PY+vQ8hZpUZ/cpYg=
@@ -123,8 +121,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.0 h1:+epNPbD5EqgpEMm5wrl4Hqts3jZ
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.0/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/tests/integration/testutils/testserver.go
+++ b/tests/integration/testutils/testserver.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/prometheus/client_golang/prometheus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/endpoints"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/server"
@@ -149,13 +150,7 @@ func testConfig(t *testing.T, setup AuthenticatorTestFrameworkSetup) (config.Con
 		return cfg, errors.New("cluster ID cannot be empty")
 	}
 
-	partitionKeys := []string{}
-	partitionMap := map[string]endpoints.Partition{}
-	for _, p := range endpoints.DefaultPartitions() {
-		partitionMap[p.ID()] = p
-		partitionKeys = append(partitionKeys, p.ID())
-	}
-	if _, ok := partitionMap[cfg.PartitionID]; !ok {
+	if !slices.Contains(endpoints.PARTITIONS, cfg.PartitionID) {
 		return cfg, errors.New("Invalid partition")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR removes calls to the `github.com/aws/aws-sdk-go/aws/endpoints` package. Due to the Go SDK making details about valid endpoints private, and to avoid hardcoding a list of supported regions, hostname verification will now use `sts.EndpointResolverV2` to verify hostnames. Note that this will make the verification process weaker, turning the check into making sure that a hostname was valid to simply making sure that the hostname follows the correct format and belongs to a valid AWS partition. However, since Amazon owns its partition's domains, any malformed hostnames will be rejected and bad actors should not be able to get their hostnames through. 

This is meant to move the repository away from the AWS SDK Go V1, which is set to be deprecated on July 31, 2025.

Tagging @kmala @yue9944882 and @micahhausler as this approach has been discussed with them.

Testing:
First, I tested that an account can generate a token and verify it. Checked that the token is verified when checked against the same partition, and rejected when not. Tested in accounts across two partitions (`aws` and `aws-cn`) to ensure this code maintains the general approach of partition verification.

In the US account:
```
export US_TOKEN=$(aws-iam-authenticator/_output/bin/aws-iam-authenticator token --cluster-id testcluster --token-only)

# same partition - expect success
(25-07-22 17:20:55) <0> [~/workplace/aws-iam-authenticator] 
dev-dsk % /aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=cluster —token=$US_TOKEN —partition=aws
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
&{ARN:arn:aws:sts::{account-id}:assumed-role/{role}/{session} CanonicalARN:arn:aws:iam::{account-id}:role/admin AccountID:{account-id} UserID:{user-id} SessionName:{session} AccessKeyID:{access-key-id} STSEndpoint:sts.us-west-2.amazonaws.com}

# different partition - expect failure
(25-07-22 17:20:59) <0> [~/workplace/aws-iam-authenticator] 
dev-dsk % /aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=cluster —token=$US_TOKEN —partition=aws-cn
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
could not verify token: input token was not properly formatted: partition {aws-cn} does not support hostname sts.us-west-2.amazonaws.com
```

In the China account:
```
export US_TOKEN=$(aws-iam-authenticator/_output/bin/aws-iam-authenticator token --cluster-id testcluster --token-only)

# different partition - expect failure
(25-07-22 17:20:55) <0> [~/workplace/aws-iam-authenticator] 
dev-dsk % aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=testcluster —token=$US_TOKEN —partition=aws
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
&{ARN:arn:aws:sts::{account-id}:assumed-role/{role}/{session} CanonicalARN:arn:aws:iam::{account-id}:role/admin AccountID:{account-id} UserID:{user-id} SessionName:{session} AccessKeyID:{access-key-id} STSEndpoint:sts.us-west-2.amazonaws.com}

# same partition - expect success
(25-07-22 17:20:59) <0> [~/workplace/aws-iam-authenticator] 
dev-dsk % aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=testcluster —token=$US_TOKEN —partition=aws-cn
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
could not verify token: input token was not properly formatted: partition {aws-cn} does not support hostname sts.us-west-2.amazonaws.com
```

Then, I tested verification of tokens that were not generated in the same partition. I verified that tokens can still be verified, provided that the verifier is given the correct region.

In the US account:
```
# partition doesn't match token's - expect failure
(25-07-22 17:26:02) <1> [~/workplace/aws-iam-authenticator]
dev-dsk %aws-iam-authenticator/_output/bin/aws-iam-authenticator verify --cluster-id=testcluster --token=$CHINA_TOKEN --partition=aws
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
could not verify token: input token was not properly formatted: partition {aws} does not support hostname sts.cn-north-1.amazonaws.com.cn

# partition matches token's - expect success
(25-07-22 17:26:04) <1> [~/workplace/aws-iam-authenticator] 
dev-dsk % aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=testcluster —token=$CHINA_TOKEN —partition=aws-cn
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
&{ARN:arn:aws-cn:sts::{cn-account-id}:assumed-role/ReadOnly/{session} CanonicalARN:arn:aws-cn:iam::{cn-account-id}:role/ReadOnly AccountID:{cn-account-id} UserID:{user-id} SessionName:{session} AccessKeyID:{access-key-id} STSEndpoint:sts.cn-north-1.amazonaws.com.cn}
```
In the China account:
```
# partition matches token's - expect success
(25-07-22 17:25:07) <0> [~/workplace/aws-iam-authenticator] 
dev-dsk % aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=testcluster —token=$US_TOKEN —partition=aws
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
&{ARN:arn:aws:sts::{account-id}:assumed-role/{role}/{session} CanonicalARN:arn:aws:iam::{account-id}:role/admin AccountID:{account-id} UserID:{user-id} SessionName:{session} AccessKeyID:{access-key-id} STSEndpoint:sts.us-west-2.amazonaws.com}

# partition doesn't match token's - expect failure
(25-07-22 17:25:09) <0> [~/workplace/aws-iam-authenticator] 
dev-dsk % aws-iam-authenticator/_output/bin/aws-iam-authenticator verify —cluster-id=testcluster —token=$US_TOKEN —partition=aws-cn
[Warn] Region not found in instance metadata, err: operation error ec2imds: GetRegion, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
could not verify token: input token was not properly formatted: partition {aws-cn} does not support hostname sts.us-west-2.amazonaws.com
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

