### PR TITLE
fix: resolve goreleaser v2 deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # Configuration for https://goreleaser.com/
+version: 2
 project_name: authenticator
 
 builds:
@@ -23,11 +24,12 @@ builds:
       - "-s -w -X sigs.k8s.io/aws-iam-authenticator/pkg.Version={{.Version}} -X sigs.k8s.io/aws-iam-authenticator/pkg.CommitID={{.Commit}} -buildid=''"
 
 snapshot:
-  name_template: "git-{{.ShortCommit}}"
+  version_template: "git-{{.ShortCommit}}"
 
 archives:
   - id: bin
-    format: binary
+    formats:
+      - binary
 
 release:
   github:

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ image: .image-linux-$(GOARCH)
 .PHONY: goreleaser
 goreleaser:
 ifndef GORELEASER
-	$(error "goreleaser not found (`go get -u -v github.com/goreleaser/goreleaser` to fix)")
+	$(error "goreleaser not found (`go install github.com/goreleaser/goreleaser/v2@latest` to fix)")
 endif
-	$(GORELEASER) --skip-publish --clean --snapshot
+	$(GORELEASER) release --skip=publish --clean --snapshot
 
 .PHONY: test
 test:


### PR DESCRIPTION
## Summary

- Add explicit `version: 2` declaration required by goreleaser v2
- Rename deprecated `snapshot.name_template` to `snapshot.version_template`
- Rename deprecated `archives.format` (string) to `archives.formats` (list)
- Replace removed `--skip-publish` flag with `--skip=publish` in Makefile goreleaser target
- Add explicit `release` subcommand required by goreleaser v2
- Update goreleaser install hint from `go get` to `go install` with v2 module path

Resolves the deprecated warnings from the recent release output https://github.com/kubernetes-sigs/aws-iam-authenticator/actions/runs/23367905386/job/67985570424