### PR TITLE
fix: build failure due to stale gcb image by updating to latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
     entrypoint: /buildx-entrypoint
     args:
       - build


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix gcb build image tag to use latest, as current builds are failing to pull stale gcb image with below error:

```
Error response from daemon: manifest for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a not found: manifest unknown: Failed to fetch "v20221214-1b4dd4d69a"
```

Ref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/aws-encryption-provider-push-images/2044177037203083264

