### PR TITLE
fix: create-release workflow failures

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           ssh-key: "${{ secrets.RELEASE_KEY }}"
@@ -30,12 +30,12 @@ jobs:
           hack/tag-release.sh
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: .go-version
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `create-release.yml` github workflow by pinning actions to specific SHA.
Failing due to error:
```
Error: The actions actions/checkout@v6, actions/setup-go@v6, and goreleaser/goreleaser-action@v7 are not allowed in kubernetes-sigs/aws-iam-authenticator because all actions must be pinned to a full-length commit SHA.
```
Ref: https://github.com/kubernetes-sigs/aws-iam-authenticator/actions/runs/24518390407/job/71668879659

