### PR TITLE
fix: reject malformed mapping ARN in userIDStrict mode for dynamic files

### DIFF
--- a/pkg/mapper/dynamicfile/dynamicfile_test.go
+++ b/pkg/mapper/dynamicfile/dynamicfile_test.go
@@ -593,6 +593,44 @@ func TestMap(t *testing.T) {
 			expectedError:     errutil.ErrIDAndARNMismatch,
 		},
 		{
+			description: "UserID strict: malformed RoleARN is rejected even when UserID matches.",
+			identity: &token.Identity{
+				ARN:          "arn:aws:sts::012345678912:assumed-role/RealRole/session",
+				CanonicalARN: "arn:aws:iam::012345678912:role/RealRole",
+				UserID:       "AROAAAAAAAAAAAAAAAAAA",
+			},
+			users: map[string]config.UserMapping{},
+			roles: map[string]config.RoleMapping{
+				"AROAAAAAAAAAAAAAAAAAA": {
+					RoleARN:  "not-an-arn",
+					UserId:   "AROAAAAAAAAAAAAAAAAAA",
+					Username: "kubernetes-admin",
+					Groups:   []string{"system:masters"},
+				},
+			},
+			expectedIDMapping: nil,
+			expectedError:     errutil.ErrIDAndARNMismatch,
+		},
+		{
+			description: "UserID strict: malformed UserARN is rejected even when UserID matches.",
+			identity: &token.Identity{
+				ARN:          "arn:aws:iam::012345678912:user/real",
+				CanonicalARN: "arn:aws:iam::012345678912:user/real",
+				UserID:       "AIDAAAAAAAAAAAAAAAAAA",
+			},
+			users: map[string]config.UserMapping{
+				"AIDAAAAAAAAAAAAAAAAAA": {
+					UserARN:  "garbage",
+					UserId:   "AIDAAAAAAAAAAAAAAAAAA",
+					Username: "kubernetes-admin",
+					Groups:   []string{"system:masters"},
+				},
+			},
+			roles:             map[string]config.RoleMapping{},
+			expectedIDMapping: nil,
+			expectedError:     errutil.ErrIDAndARNMismatch,
+		},
+		{
 			description: "UserID strict: No ARN provided.",
 			identity: &token.Identity{
 				ARN:          "arn:aws:iam::012345678912:user/matt",

--- a/pkg/mapper/dynamicfile/mapper.go
+++ b/pkg/mapper/dynamicfile/mapper.go
@@ -73,7 +73,15 @@ func (m *DynamicFileMapper) match(canonicalARN string, mappingARN string) error 
 		// If ARN is provided, ARN must be validated along with UserID.  This avoids having to
 		// support IAM user name/ARN changes. Without preventing this the mapping would look
 		// invalid but still work and auditing would be difficult/impossible.
-		strippedArn, _ := arn.StripPath(mappingARN)
+		if mappingARN == "" {
+			// No ARN configured for this mapping; UserID match alone is sufficient.
+			return nil
+		}
+		strippedArn, err := arn.StripPath(mappingARN)
+		if err != nil {
+			logrus.Infof("invalid mapping arn in dynamic file: %q, treating as mismatch: %v", mappingARN, err)
+			return errutil.ErrIDAndARNMismatch
+		}
 		logrus.Infof("additional arn comparison for IAM arn. arn from STS response is %s, arn in mapper is %s",
 			canonicalARN, strings.ToLower(strippedArn))
 		if strippedArn != "" && canonicalARN != strings.ToLower(strippedArn) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The error returned by arn.StripPath was discarded when validating
rolearn/userarn against the STS canonical ARN. A malformed ARN caused
StripPath to return an empty string with an error; the discarded error
left strippedArn empty, the ARN comparison was skipped, and strict
mode silently degraded to UserID-only validation.

The intent of strict mode is that both userid and ARN must match. With
this bug, an entry with a valid userid and a malformed rolearn/userarn
bypassed the ARN check, so the mapping succeeded as long as the
authenticated identity's userid matched. Any username/groups specified
in that entry were applied, including privileged groups such as
system:masters.

Capture the parse error and return errutil.ErrIDAndARNMismatch.
Preserve the "no ARN configured" path with an explicit empty-string
short-circuit so UserID-only mappings still work.

Add TestMap cases for malformed RoleARN and UserAR