### PR TITLE
fix: honor reservedPrefixConfig for ConfigMap and CRD backends

### DIFF
--- a/pkg/mapper/configmap/configmap_test.go
+++ b/pkg/mapper/configmap/configmap_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
 )
 
 func init() {
@@ -374,6 +375,33 @@ func TestBadParseMapSingleQuote(t *testing.T) {
 	emptyMap := map[string]string{}
 	if !reflect.DeepEqual(emptyMap, m2) {
 		t.Fatalf("unexpected %v != %v", emptyMap, m2)
+	}
+}
+
+func TestConfigMapMapperReservedPrefixesFromConfig(t *testing.T) {
+	cfg := config.Config{
+		ReservedPrefixConfig: map[string]config.ReservedPrefixConfig{
+			mapper.ModeEKSConfigMap: {
+				BackendMode:               mapper.ModeEKSConfigMap,
+				UsernamePrefixReserveList: []string{"system:", "eks:"},
+			},
+		},
+	}
+	m := &ConfigMapMapper{}
+	if value, exists := cfg.ReservedPrefixConfig[mapper.ModeEKSConfigMap]; exists {
+		m.usernamePrefixReserveList = value.UsernamePrefixReserveList
+	}
+	got := m.UsernamePrefixReserveList()
+	want := []string{"system:", "eks:"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UsernamePrefixReserveList() = %v, want %v", got, want)
+	}
+}
+
+func TestConfigMapMapperReservedPrefixesEmptyByDefault(t *testing.T) {
+	m := &ConfigMapMapper{}
+	if got := m.UsernamePrefixReserveList(); len(got) != 0 {
+		t.Errorf("UsernamePrefixReserveList() = %v, want empty, got %v", got, got)
 	}
 }
 

--- a/pkg/mapper/configmap/mapper.go
+++ b/pkg/mapper/configmap/mapper.go
@@ -13,6 +13,7 @@ import (
 // ConfigMapMapper maps IAM identities using the aws-auth Kubernetes ConfigMap.
 type ConfigMapMapper struct { //nolint:revive // exported: stutter preserved for backwards compatibility
 	*MapStore
+	usernamePrefixReserveList []string
 }
 
 var _ mapper.Mapper = &ConfigMapMapper{}
@@ -23,7 +24,11 @@ func NewConfigMapMapper(cfg config.Config) (*ConfigMapMapper, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ConfigMapMapper{ms}, nil
+	cm := &ConfigMapMapper{MapStore: ms}
+	if value, exists := cfg.ReservedPrefixConfig[mapper.ModeEKSConfigMap]; exists {
+		cm.usernamePrefixReserveList = value.UsernamePrefixReserveList
+	}
+	return cm, nil
 }
 
 // Name returns the name of this mapper mode.
@@ -70,5 +75,5 @@ func (m *ConfigMapMapper) IsAccountAllowed(accountID string) bool {
 
 // UsernamePrefixReserveList returns the list of reserved username prefixes for this mapper.
 func (m *ConfigMapMapper) UsernamePrefixReserveList() []string {
-	return []string{}
+	return m.usernamePrefixReserveList
 }

--- a/pkg/mapper/crd/mapper.go
+++ b/pkg/mapper/crd/mapper.go
@@ -30,6 +30,8 @@ type CRDMapper struct { //nolint:revive // exported: stutter preserved for backw
 	iamMappingsSynced cache.InformerSynced
 	// iamMappingsIndex is a custom indexer which allows for indexing on canonical arns
 	iamMappingsIndex cache.Indexer
+	// usernamePrefixReserveList holds reserved username prefixes from cfg.ReservedPrefixConfig that mapped usernames must not begin with.
+	usernamePrefixReserveList []string
 }
 
 var _ mapper.Mapper = &CRDMapper{}
@@ -69,7 +71,17 @@ func NewCRDMapper(cfg config.Config) (*CRDMapper, error) {
 
 	ctrl := controller.New(kubeClient, iamClient, iamMappingInformer)
 
-	return &CRDMapper{ctrl, iamInformerFactory, iamMappingsSynced, iamMappingsIndex}, nil
+	cm := &CRDMapper{
+		Controller:         ctrl,
+		iamInformerFactory: iamInformerFactory,
+		iamMappingsSynced:  iamMappingsSynced,
+		iamMappingsIndex:   iamMappingsIndex,
+	}
+	if value, exists := cfg.ReservedPrefixConfig[mapper.ModeCRD]; exists {
+		cm.usernamePrefixReserveList = value.UsernamePrefixReserveList
+	}
+
+	return cm, nil
 }
 
 // NewCRDMapperWithIndexer creates a CRDMapper using the provided cache indexer, for testing.
@@ -133,5 +145,5 @@ func (m *CRDMapper) IsAccountAllowed(_ string) bool {
 
 // UsernamePrefixReserveList returns username prefixes reserved by this mapper.
 func (m *CRDMapper) UsernamePrefixReserveList() []string {
-	return []string{}
+	return m.usernamePrefixReserveList
 }

--- a/pkg/mapper/crd/mapper_test.go
+++ b/pkg/mapper/crd/mapper_test.go
@@ -1,0 +1,36 @@
+package crd
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/config"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/mapper"
+)
+
+func TestCRDMapperReservedPrefixesFromConfig(t *testing.T) {
+	cfg := config.Config{
+		ReservedPrefixConfig: map[string]config.ReservedPrefixConfig{
+			mapper.ModeCRD: {
+				BackendMode:               mapper.ModeCRD,
+				UsernamePrefixReserveList: []string{"system:", "eks:"},
+			},
+		},
+	}
+	m := &CRDMapper{}
+	if value, exists := cfg.ReservedPrefixConfig[mapper.ModeCRD]; exists {
+		m.usernamePrefixReserveList = value.UsernamePrefixReserveList
+	}
+	got := m.UsernamePrefixReserveList()
+	want := []string{"system:", "eks:"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UsernamePrefixReserveList() = %v, want %v", got, want)
+	}
+}
+
+func TestCRDMapperReservedPrefixesEmptyByDefault(t *testing.T) {
+	m := &CRDMapper{}
+	if got := m.UsernamePrefixReserveList(); len(got) != 0 {
+		t.Errorf("UsernamePrefixReserveList() = %v, want empty, got %v", got, got)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- panatula@ confirmed issue with mhausler@
- ISSUE: `reservedPrefixConfig` was silently ignored for the EKSConfigMap and CRD backends. `ConfigMapMapper.UsernamePrefixReserveList()` and `CRDMapper.UsernamePrefixReserveList()` hardcoded `[]string{} ` and never read `cfg.ReservedPrefixConfig`. The server enforces the reserved-prefix check only when the list is non-empty (server.go 487), so the protection was a no-op for these backends. MountedFile and DynamicFile honor it correctly.
- FIX: Wire `cfg.ReservedPrefixConfig[mapper.ModeEKSConfigMap]` and `cfg.ReservedPrefixConfig[mapper.ModeCRD] ` into the respective mappers, mirroring the existing MountedFile and DynamicFile pattern. Both mappers gain a `usernamePrefixReserveList` field populated in their constructor and returned from `UsernamePrefixReserveList()`.
- Added unit tests to test new functionality for both backends 
- `make test` and `make bin` pass
- IMPACT: clusters that configure `reservedPrefixConfig` for EKSConfigMap or CRD will now reject usernames matching the reserved prefixes. Any mapping that previously rendered to a reserved-prefix username on these backends will start failing authentication. EKS prod is unaffected (config not set). Self-managed deployments relying on the silent bypass will see those mappings break — that is the desired behavior and aligns with DynamicFile and MountedFile backend behavior.

