### PR TITLE
 feat: add STSPresignClient field to GetTokenOptions for custom credential injection

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -114,6 +114,12 @@ type Token struct {
 	Expiration time.Time
 }
 
+// STSPresignAPI is satisfied by *sts.PresignClient and allows callers to inject a
+// pre-configured client with custom credentials, region, or endpoint settings.
+type STSPresignAPI interface {
+	PresignGetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.PresignOptions)) (*v4.PresignedHTTPRequest, error)
+}
+
 // GetTokenOptions is passed to GetWithOptions to provide an extensible get token interface
 type GetTokenOptions struct {
 	Region               string
@@ -121,6 +127,9 @@ type GetTokenOptions struct {
 	AssumeRoleARN        string
 	AssumeRoleExternalID string
 	SessionName          string
+	// STSPresignClient, when set, is used directly and skips config.LoadDefaultConfig.
+	// Region, AssumeRoleARN, AssumeRoleExternalID, and SessionName are ignored.
+	STSPresignClient STSPresignAPI
 }
 
 // FormatError is returned when there is a problem with token that is
@@ -228,6 +237,10 @@ func StdinStderrTokenProvider() (string, error) {
 func (g generator) GetWithOptions(ctx context.Context, options *GetTokenOptions) (Token, error) {
 	if options.ClusterID == "" {
 		return Token{}, fmt.Errorf("ClusterID is required")
+	}
+
+	if options.STSPresignClient != nil {
+		return g.presignToken(options.ClusterID, options.STSPresignClient)
 	}
 
 	// create a session with the "base" credentials available
@@ -354,9 +367,10 @@ func withPresignFixedTime(t time.Time) func(*sts.PresignOptions) {
 
 // GetWithSTS returns a token valid for clusterID using the given STS client.
 func (g generator) GetWithSTS(clusterID string, stsClient *sts.Client) (Token, error) {
-	// Generate an sts:GetCallerIdentity presigned request
-	presignClient := sts.NewPresignClient(stsClient)
+	return g.presignToken(clusterID, sts.NewPresignClient(stsClient))
+}
 
+func (g generator) presignToken(clusterID string, presignClient STSPresignAPI) (Token, error) {
 	presignedRequest, err := presignClient.PresignGetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{},
 		func(presignOptions *sts.PresignOptions) {
 			// Configure the presigned request with a fixed time so we can control the now time for testing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
 
`GetWithOptions` calls config.LoadDefaultConfig internally, which builds its own AWS config from the environment. There is no way to pass a pre-configured STS client, so callers who have already built credentials (e.g. named profiles, cross-account role chains, or custom endpoints) are forced to re-implement the token presigning logic
  themselves rather than using this library.

This pull request  adds an optional STSPresignClient STSPresignAPI field to GetTokenOptions. When set, GetWithOptions uses it directly and skips LoadDefaultConfig entirely. When nil, existing behavior is unchanged.

  The STSPresignAPI interface is narrow — a single PresignGetCallerIdentity method — and is satisfied by *sts.PresignClient without any adapter.

  The presigning logic is extracted from GetWithSTS into a private presignToken helper shared by both paths, so there is no duplication.