### PR TITLE
Set a custom User-Agent on STS token verification requests

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -106,6 +106,9 @@ const (
 	kindExecCredential = "ExecCredential" //nolint:gosec // G101: false positive, this is a Kubernetes API kind name not a credential
 	execInfoEnvKey     = "KUBERNETES_EXEC_INFO"
 	stsServiceID       = "sts"
+	// userAgentPrefix is used to build the User-Agent header the verifier sends
+	// when validating pre-signed sts:GetCallerIdentity URLs against STS.
+	userAgentPrefix = "aws-iam-authenticator"
 )
 
 // Token is generated and used by Kubernetes client-go to authenticate with a Kubernetes cluster.
@@ -688,6 +691,7 @@ func (v *tokenVerifier) Verify(token string) (*Identity, error) {
 	}
 	req.Header.Set(clusterIDHeader, v.clusterID)
 	req.Header.Set("accept", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("%s/%s", userAgentPrefix, pkg.Version))
 
 	response, err := v.client.Do(req)
 	if err != nil {

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/pkg/apis/clientauthentication"
 	clientauthv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+	"sigs.k8s.io/aws-iam-authenticator/pkg"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/endpoints"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 )
@@ -444,6 +445,42 @@ func TestVerifyCanonicalARN(t *testing.T) {
 	}
 	if identity.CanonicalARN != canonicalARN {
 		t.Errorf("expected CannonicalARN to be %q but was %q", canonicalARN, identity.CanonicalARN)
+	}
+}
+
+// capturingRoundTripper records the last request it sees and returns a fixed
+// successful GetCallerIdentity response.
+type capturingRoundTripper struct {
+	lastRequest *http.Request
+	body        string
+}
+
+func (rt *capturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.lastRequest = req
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader([]byte(rt.body))),
+	}, nil
+}
+
+func TestVerifySetsUserAgent(t *testing.T) {
+	rt := &capturingRoundTripper{
+		body: jsonResponse("arn:aws:iam::123456789012:user/Alice", "123456789012", "Alice"),
+	}
+	verifier := &tokenVerifier{
+		client:            &http.Client{Transport: rt},
+		validSTShostnames: make(map[string]bool),
+		partition:         "aws",
+	}
+	if _, err := verifier.Verify(validToken); err != nil {
+		t.Fatalf("received unexpected error: %s", err)
+	}
+	if rt.lastRequest == nil {
+		t.Fatal("expected an STS request to be made but none was captured")
+	}
+	want := fmt.Sprintf("%s/%s", userAgentPrefix, pkg.Version)
+	if got := rt.lastRequest.Header.Get("User-Agent"); got != want {
+		t.Errorf("expected User-Agent header %q but got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR has the authenticator server set a custom user agent when communicating to AWS STS, to make it a bit easier at a glance to understand if a given GetCallerIdentity request originates from an EKS cluster control plane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No issue addressed by this.
