### PR TITLE
Update Dockerfile Go images to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG image=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2026-03-10-1773177752.2023
-ARG golang_image=public.ecr.aws/eks-distro-build-tooling/golang:1.26.4
+ARG golang_image=public.ecr.aws/eks-distro-build-tooling/golang:1.26.5
 
 FROM --platform=$BUILDPLATFORM $golang_image AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-iam-authenticator
@@ -23,7 +23,7 @@ ARG TARGETOS TARGETARCH
 RUN GOPROXY=direct GOOS=$TARGETOS GOARCH=$TARGETARCH make bin
 RUN chown 65532 _output/bin/aws-iam-authenticator
 
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26.4.2023 AS go-runner
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26.5.2023 AS go-runner
 
 FROM --platform=$TARGETPLATFORM $image
 COPY --from=go-runner /go-runner /usr/local/bin/go-runner


### PR DESCRIPTION
Bump golang and go-runner images to match .go-version (1.26.5).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update Dockerfile Go images to 1.26.5 to fix CVEs. The .go-version was already bumped to 1.26.5 in commit https://github.com/kubernetes-sigs/aws-iam-authenticator/commit/d17e344f258c5f65df9238db38a35eefb0889b0d

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

