### PR TITLE
fix: pin the Go toolchain to 1.26.5 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/aws-iam-authenticator
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.29


### PR DESCRIPTION
**What this PR does / why we need it**:

`.go-version` and the Dockerfile were both moved to Go 1.26.5, but `go.mod` still declares `go 1.26.0` with no `toolchain` directive. CI and the published image therefore build on 1.26.5 while anyone consuming the module directly — `go install sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator@latest`, or vendoring it — can still compile against an older stdlib, which is what the scanners in #1074 report against.

Adding `toolchain go1.26.5` makes the floor part of the module itself. The `go` directive is deliberately left at 1.26.0 so the minimum language version is unchanged.

Scoped to the root module, which produces the released binary. Happy to extend it to `tests/integration` and `tests/e2e` if you'd rather they stayed consistent.

Credit to @chithreshazad, who proposed the Dockerfile half of this in #1088 before #1091 landed the same change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Refs #1074 — this closes the `go.mod` half; the release itself is still what that issue is ultimately waiting on.

**Special notes for your reviewer**:

`go build ./cmd/aws-iam-authenticator` now stamps `go1.26.5` under `go version -m`; `go test ./pkg/...` passes.

```release-note
Pin the Go toolchain to 1.26.5 in go.mod so direct module builds use the same stdlib as CI and the published image.
```
