### PR TITLE
added ec2 metrics: ec2_responses_total and ec2_connection_failures_total

### DIFF
--- a/pkg/ec2provider/ec2provider.go
+++ b/pkg/ec2provider/ec2provider.go
@@ -70,6 +70,21 @@ type ec2ProviderImpl struct {
 	privateDNSCache    *ec2PrivateDNSCache
 	ec2Requests        *ec2Requests
 	instanceIDsChannel chan string
+	region             string
+}
+
+// ec2ResponseCode returns the specific HTTP status code (e.g. "400"/"503") for
+// a non-nil DescribeInstances error that carried an HTTP response, or "" if the
+// error had no HTTP response / a zero status (a transport failure, which is not
+// counted here).
+func ec2ResponseCode(err error) string {
+	var respErr *smithyhttp.ResponseError
+	if errors.As(err, &respErr) {
+		if code := respErr.HTTPStatusCode(); code != 0 {
+			return fmt.Sprint(code)
+		}
+	}
+	return ""
 }
 
 // New creates and starts a new EC2Provider that resolves instance IDs to private DNS names.
@@ -87,6 +102,7 @@ func New(ctx context.Context, roleARN, sourceARN, region string, qps int, burst 
 		privateDNSCache:    dnsCache,
 		ec2Requests:        ec2Requests,
 		instanceIDsChannel: make(chan string, maxChannelSize),
+		region:             region,
 	}
 }
 
@@ -207,9 +223,15 @@ func (p *ec2ProviderImpl) GetPrivateDNSName(ctx context.Context, id string) (str
 		InstanceIds: []string{id},
 	})
 	if err != nil {
+		if code := ec2ResponseCode(err); code != "" {
+			metrics.Get().EC2Responses.WithLabelValues(code, p.region).Inc()
+		} else {
+			metrics.Get().EC2ConnectionFailure.WithLabelValues(p.region).Inc()
+		}
 		p.unsetRequestInFlightForInstanceID(id)
 		return "", fmt.Errorf("failed querying private DNS from EC2 API for node %s: %s ", id, err.Error())
 	}
+	metrics.Get().EC2Responses.WithLabelValues("200", p.region).Inc()
 	for _, reservation := range output.Reservations {
 		for _, instance := range reservation.Instances {
 			if aws.ToString(instance.InstanceId) == id {
@@ -269,7 +291,13 @@ func (p *ec2ProviderImpl) getPrivateDNSAndPublishToCache(ctx context.Context, in
 	})
 	if err != nil {
 		logrus.Errorf("Batch call failed querying private DNS from EC2 API for nodes [%s] : with error = []%s ", instanceIDList, err.Error())
+		if code := ec2ResponseCode(err); code != "" {
+			metrics.Get().EC2Responses.WithLabelValues(code, p.region).Inc()
+		} else {
+			metrics.Get().EC2ConnectionFailure.WithLabelValues(p.region).Inc()
+		}
 	} else {
+		metrics.Get().EC2Responses.WithLabelValues("200", p.region).Inc()
 		if output.NextToken != nil {
 			logrus.Debugf("Successfully got the batch result , output.NextToken = %s ", *output.NextToken)
 		} else {

--- a/pkg/ec2provider/ec2provider.go
+++ b/pkg/ec2provider/ec2provider.go
@@ -73,11 +73,7 @@ type ec2ProviderImpl struct {
 	region             string
 }
 
-// ec2ResponseCode returns the specific HTTP status code (e.g. "400"/"503") for
-// a non-nil DescribeInstances error that carried an HTTP response, or "" if the
-// error had no HTTP response / a zero status (a transport failure, which is not
-// counted here).
-func ec2ResponseCode(err error) string {
+func ec2ErrorResponseCode(err error) string {
 	var respErr *smithyhttp.ResponseError
 	if errors.As(err, &respErr) {
 		if code := respErr.HTTPStatusCode(); code != 0 {
@@ -85,6 +81,13 @@ func ec2ResponseCode(err error) string {
 		}
 	}
 	return ""
+}
+
+func ec2SuccessResponseCode(metadata smithymiddleware.Metadata) string {
+	if raw, ok := middleware.GetRawResponse(metadata).(*smithyhttp.Response); ok {
+		return fmt.Sprint(raw.StatusCode)
+	}
+	return "200"
 }
 
 // New creates and starts a new EC2Provider that resolves instance IDs to private DNS names.
@@ -223,7 +226,7 @@ func (p *ec2ProviderImpl) GetPrivateDNSName(ctx context.Context, id string) (str
 		InstanceIds: []string{id},
 	})
 	if err != nil {
-		if code := ec2ResponseCode(err); code != "" {
+		if code := ec2ErrorResponseCode(err); code != "" {
 			metrics.Get().EC2Responses.WithLabelValues(code, p.region).Inc()
 		} else {
 			metrics.Get().EC2ConnectionFailure.WithLabelValues(p.region).Inc()
@@ -231,7 +234,7 @@ func (p *ec2ProviderImpl) GetPrivateDNSName(ctx context.Context, id string) (str
 		p.unsetRequestInFlightForInstanceID(id)
 		return "", fmt.Errorf("failed querying private DNS from EC2 API for node %s: %s ", id, err.Error())
 	}
-	metrics.Get().EC2Responses.WithLabelValues("200", p.region).Inc()
+	metrics.Get().EC2Responses.WithLabelValues(ec2SuccessResponseCode(output.ResultMetadata), p.region).Inc()
 	for _, reservation := range output.Reservations {
 		for _, instance := range reservation.Instances {
 			if aws.ToString(instance.InstanceId) == id {
@@ -291,13 +294,13 @@ func (p *ec2ProviderImpl) getPrivateDNSAndPublishToCache(ctx context.Context, in
 	})
 	if err != nil {
 		logrus.Errorf("Batch call failed querying private DNS from EC2 API for nodes [%s] : with error = []%s ", instanceIDList, err.Error())
-		if code := ec2ResponseCode(err); code != "" {
+		if code := ec2ErrorResponseCode(err); code != "" {
 			metrics.Get().EC2Responses.WithLabelValues(code, p.region).Inc()
 		} else {
 			metrics.Get().EC2ConnectionFailure.WithLabelValues(p.region).Inc()
 		}
 	} else {
-		metrics.Get().EC2Responses.WithLabelValues("200", p.region).Inc()
+		metrics.Get().EC2Responses.WithLabelValues(ec2SuccessResponseCode(output.ResultMetadata), p.region).Inc()
 		if output.NextToken != nil {
 			logrus.Debugf("Successfully got the batch result , output.NextToken = %s ", *output.NextToken)
 		} else {

--- a/pkg/ec2provider/ec2provider_test.go
+++ b/pkg/ec2provider/ec2provider_test.go
@@ -2,8 +2,11 @@ package ec2provider
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/metrics"
 )
@@ -282,4 +286,131 @@ func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	return resp, nil
+}
+
+type statusRoundTripper struct {
+	status int
+	body   string
+	err    error
+}
+
+func (s *statusRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &http.Response{
+		StatusCode: s.status,
+		Header:     make(http.Header),
+		// Body must be non-nil: the EC2 error deserializer io.Copy's from it.
+		Body: io.NopCloser(strings.NewReader(s.body)),
+	}, nil
+}
+
+func newTestEC2Client(rt http.RoundTripper) *ec2.Client {
+	cfg := aws.Config{
+		Region: "us-west-2",
+		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(
+			"AKID", "SECRET", "SESSION")),
+		HTTPClient: &http.Client{Transport: rt},
+		RetryMaxAttempts: 1,
+	}
+	return ec2.NewFromConfig(cfg)
+}
+
+func TestEc2ResponseCodeWithRealSDKError(t *testing.T) {
+	// Shape the real ec2query deserializer expects (Errors>Error>Code/Message).
+	errorBody := func(code, msg string) string {
+		return `<Response><Errors><Error><Code>` + code + `</Code><Message>` + msg +
+			`</Message></Error></Errors><RequestID>test-request-id</RequestID></Response>`
+	}
+
+	tests := []struct {
+		name string
+		rt   *statusRoundTripper
+		want string
+	}{
+		{
+			name: "400 throttling response",
+			rt: &statusRoundTripper{
+				status: 400,
+				body:   errorBody("RequestLimitExceeded", "Rate exceeded"),
+			},
+			want: "400",
+		},
+		{
+			name: "400 invalid instance id",
+			rt: &statusRoundTripper{
+				status: 400,
+				body:   errorBody("InvalidInstanceID.NotFound", "The instance ID does not exist"),
+			},
+			want: "400",
+		},
+		{
+			name: "403 unauthorized",
+			rt: &statusRoundTripper{
+				status: 403,
+				body:   errorBody("UnauthorizedOperation", "You are not authorized"),
+			},
+			want: "403",
+		},
+		{
+			name: "503 service unavailable",
+			rt: &statusRoundTripper{
+				status: 503,
+				body:   errorBody("ServiceUnavailable", "Service unavailable"),
+			},
+			want: "503",
+		},
+		{
+			name: "transport failure (no HTTP response)",
+			rt: &statusRoundTripper{
+				err: errors.New("dial tcp 10.0.0.1:443: connect: connection refused"),
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestEC2Client(tt.rt)
+			_, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
+				InstanceIds: []string{"i-1234567890abcdef0"},
+			})
+			if err == nil {
+				t.Fatal("expected an error from DescribeInstances, got nil")
+			}
+			if got := ec2ResponseCode(err); got != tt.want {
+				t.Errorf("ec2ResponseCode() = %q, want %q (err was: %v)", got, tt.want, err)
+			}
+		})
+	}
+}
+
+func TestEc2ResponseCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: "",
+		},
+		{
+			name: "response error with zero status",
+			err: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: 0}},
+				Err:      errors.New("x"),
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ec2ResponseCode(tt.err)
+			if got != tt.want {
+				t.Errorf("ec2ResponseCode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/ec2provider/ec2provider_test.go
+++ b/pkg/ec2provider/ec2provider_test.go
@@ -311,7 +311,7 @@ func newTestEC2Client(rt http.RoundTripper) *ec2.Client {
 		Region: "us-west-2",
 		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(
 			"AKID", "SECRET", "SESSION")),
-		HTTPClient: &http.Client{Transport: rt},
+		HTTPClient:       &http.Client{Transport: rt},
 		RetryMaxAttempts: 1,
 	}
 	return ec2.NewFromConfig(cfg)
@@ -368,17 +368,28 @@ func TestEc2ResponseCodeWithRealSDKError(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "200 success",
+			rt: &statusRoundTripper{
+				status: 200,
+				body:   "",
+			},
+			want: "200",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newTestEC2Client(tt.rt)
-			_, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
+			output, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 				InstanceIds: []string{"i-1234567890abcdef0"},
 			})
 			if err == nil {
-				t.Fatal("expected an error from DescribeInstances, got nil")
+				if got := ec2SuccessResponseCode(output.ResultMetadata); got != tt.want {
+					t.Errorf("ec2SuccessResponseCode() = %q, want %q", got, tt.want)
+				}
+				return
 			}
-			if got := ec2ResponseCode(err); got != tt.want {
+			if got := ec2ErrorResponseCode(err); got != tt.want {
 				t.Errorf("ec2ResponseCode() = %q, want %q (err was: %v)", got, tt.want, err)
 			}
 		})
@@ -407,7 +418,7 @@ func TestEc2ResponseCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ec2ResponseCode(tt.err)
+			got := ec2ErrorResponseCode(tt.err)
 			if got != tt.want {
 				t.Errorf("ec2ResponseCode() = %q, want %q", got, tt.want)
 			}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -44,6 +44,8 @@ type Metrics struct {
 	EC2DescribeInstanceCallCount prometheus.Counter
 	StsConnectionFailure         *prometheus.CounterVec
 	StsResponses                 *prometheus.CounterVec
+	EC2Responses                 *prometheus.CounterVec
+	EC2ConnectionFailure         *prometheus.CounterVec
 	DynamicFileFailures          prometheus.Counter
 	StsThrottling                *prometheus.CounterVec
 	E2ELatency                   *prometheus.HistogramVec
@@ -89,6 +91,20 @@ func createMetrics(reg prometheus.Registerer) Metrics {
 				Name:      "sts_responses_total",
 				Help:      "Sts responses with error code label",
 			}, []string{"ResponseCode", "StsRegion"},
+		),
+		EC2Responses: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Name:      "ec2_responses_total",
+				Help:      "EC2 responses with error code label",
+			}, []string{"ResponseCode", "Region"},
+		),
+		EC2ConnectionFailure: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Name:      "ec2_connection_failures_total",
+				Help:      "EC2 call could not succeed or timed out",
+			}, []string{"Region"},
 		),
 		Latency: factory.NewHistogramVec(
 			prometheus.HistogramOpts{


### PR DESCRIPTION
Adds outcome metrics for the authenticator's EC2 DescribeInstances calls (used to resolve {{EC2PrivateDNSName}}). Currently only ec2_describe_instances_calls_total exists, which counts attempts but gives no insight into their results.

This adds two metrics, modeled on the existing STS instrumentation:

ec2_responses_total{ResponseCode, Region} — counts calls that got an HTTP response, labeled by status code (200, 400, 503, ...).
ec2_connection_failures_total{Region} — counts calls that got no response at all (timeout / unreachable / connection error), mirroring sts_connection_failures_total.
Together they let operators distinguish EC2 errors from EC2 being unreachable, spot throttling/regional issues, and compute error rates, matching the visibility already available for the STS path.

Testing: Unit testing. Built the image and deployed it to a beta EKS cluster, then curled the authenticator's /metrics endpoint to confirm the new ec2_responses_total and ec2_connection_failures_total metrics are registered and exported. Verified successful DescribeInstances calls increment ec2_responses_total{ResponseCode="200"} with the expected Region label.

